### PR TITLE
Channel Flow and LeadBot in the plugin, rebuilt settings page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,10 +1,18 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./components/ui/tabs";
 import logoSvg from "./assets/logo.svg";
 import { Input } from "./components/ui/input";
-import { Label } from "./components/ui/label";
 import { Button } from "./components/ui/button";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "./components/ui/use-toast";
+import {
+  ToggleField,
+  EmptyState,
+  ExternalLink,
+  Field,
+  Section,
+} from "./components/ui/section";
+import { Switch } from "./components/ui/switch";
+import { links } from "./links";
 
 interface LeadTrackrForm {
   id: string;
@@ -13,309 +21,1024 @@ interface LeadTrackrForm {
   customTitle?: string;
 }
 
+interface UtmParams {
+  sourceParam: string;
+  mediumParam: string;
+  campaignParam: string;
+  contentParam: string;
+  termParam: string;
+}
+
+interface LeadBotSettings {
+  enabled: boolean;
+  companyName: string;
+  agentName: string;
+  agentPhoto: string;
+  greeting: string;
+  phone: string;
+  whatsapp: string;
+  launcher: boolean;
+  teaser: boolean;
+  whatsappInterceptor: boolean;
+  whatsappPhoneQuestion: boolean;
+  callTracking: boolean;
+  position: "right" | "left";
+  offsetBottom: number;
+  offsetSide: number;
+  language: "auto" | "nl" | "en";
+  responseTimeText: string;
+  themePrimary: string;
+  themePrimaryHover: string;
+  themeRadius: number;
+}
+
+interface BuilderData {
+  enabled: boolean;
+  forms: LeadTrackrForm[];
+  trackAll: boolean;
+}
+
 declare global {
   interface Window {
     wpData: {
       apiUrl: string;
+      nonce: string;
       projectId: string;
-      gravityForms: {
-        enabled: boolean;
-        forms: LeadTrackrForm[];
-      };
-      cf7: {
-        enabled: boolean;
-        forms: LeadTrackrForm[];
-      };
-      elementor: {
-        enabled: boolean;
-        forms: LeadTrackrForm[];
-      };
-      wpforms: {
-        enabled: boolean;
-        forms: LeadTrackrForm[];
-      }
-      fluentForms: {
-        enabled: boolean;
-        forms: LeadTrackrForm[];
-      }
+      apiTokenSet: boolean;
+      apiTokenRequired: boolean;
+      channelFlowEnabled: boolean;
+      utmParams: UtmParams;
+      gravityForms: BuilderData;
+      cf7: BuilderData;
+      elementor: BuilderData;
+      wpforms: BuilderData;
+      fluentForms: BuilderData;
       divi: {
         enabled: boolean;
         processContactForm: boolean;
-      }
+      };
+      leadbot: LeadBotSettings;
+      leadbotSrc: string;
+      leadbotPreviewEndpoint: string;
     };
   }
 }
 
+/**
+ * One definition per form builder, so the tab strip, the empty states and the
+ * save calls all read from the same place instead of repeating the mapping.
+ */
+const BUILDERS = [
+  { tab: "gravity-forms", label: "Gravity Forms", key: "gravityForms" },
+  { tab: "contact-form-7", label: "Contact Form 7", key: "cf7" },
+  { tab: "elementor", label: "Elementor", key: "elementor" },
+  { tab: "wpforms", label: "WPForms", key: "wpforms" },
+  { tab: "fluent-forms", label: "Fluent Forms", key: "fluentForms" },
+] as const;
+
+const DEFAULT_UTM: UtmParams = {
+  sourceParam: "utm_source",
+  mediumParam: "utm_medium",
+  campaignParam: "utm_campaign",
+  contentParam: "utm_content",
+  termParam: "utm_term",
+};
+
+const UTM_FIELDS: Array<{ key: keyof UtmParams; label: string }> = [
+  { key: "sourceParam", label: "Source parameter" },
+  { key: "mediumParam", label: "Medium parameter" },
+  { key: "campaignParam", label: "Campaign parameter" },
+  { key: "contentParam", label: "Content parameter" },
+  { key: "termParam", label: "Term parameter" },
+];
+
+/**
+ * WordPress has more than one way of handing a boolean to JavaScript, and a
+ * "1" where a true was expected is enough to make the page believe it has
+ * unsaved changes. Everything from wpData goes through here first.
+ */
+function bool(value: unknown): boolean {
+  return value === true || value === 1 || value === "1";
+}
+
+function builderOf(tab: string) {
+  return BUILDERS.find((b) => b.tab === tab);
+}
+
+function isBuilderEnabled(tab: string): boolean {
+  if (tab === "divi") return window.wpData.divi.enabled;
+  const builder = builderOf(tab);
+  return builder ? window.wpData[builder.key].enabled : true;
+}
+
 function App() {
-  const [activeTab, setActiveTab] = useState<
-    "general" | "gravity-forms" | "contact-form-7" | "elementor" | "wpforms" | "fluent-forms"  | "divi" | string
-  >("general");
+  const [activeTab, setActiveTab] = useState<string>("general");
   const [projectId, setProjectId] = useState<string>("");
+  const [apiToken, setApiToken] = useState<string>("");
+  const [apiTokenSet, setApiTokenSet] = useState<boolean>(bool(window.wpData.apiTokenSet));
+  const [channelFlowEnabled, setChannelFlowEnabled] = useState<boolean>(
+    bool(window.wpData.channelFlowEnabled)
+  );
+  const [utmParams, setUtmParams] = useState<UtmParams>(window.wpData.utmParams ?? DEFAULT_UTM);
+  const [showCustomUtm, setShowCustomUtm] = useState<boolean>(false);
+  const normaliseLeadbot = (raw: LeadBotSettings): LeadBotSettings => ({
+    ...raw,
+    enabled: bool(raw.enabled),
+    launcher: bool(raw.launcher),
+    teaser: bool(raw.teaser),
+    whatsappInterceptor: bool(raw.whatsappInterceptor),
+    whatsappPhoneQuestion: bool(raw.whatsappPhoneQuestion),
+    callTracking: bool(raw.callTracking),
+    offsetBottom: Number(raw.offsetBottom),
+    offsetSide: Number(raw.offsetSide),
+    themeRadius: Number(raw.themeRadius),
+  });
+  const [leadbot, setLeadbot] = useState<LeadBotSettings>(() =>
+    normaliseLeadbot(window.wpData.leadbot)
+  );
   const [loading, setLoading] = useState<boolean>(false);
+  // Snapshots of what is actually persisted, so the page can tell the admin
+  // there is something left to save instead of quietly losing their edits.
+  const [savedGeneral, setSavedGeneral] = useState(() => ({
+    projectId: window.wpData.projectId || "",
+    channelFlowEnabled: bool(window.wpData.channelFlowEnabled),
+    utmParams: window.wpData.utmParams ?? DEFAULT_UTM,
+  }));
+  const [savedLeadbot, setSavedLeadbot] = useState<LeadBotSettings>(() =>
+    normaliseLeadbot(window.wpData.leadbot)
+  );
+  const [formsDirty, setFormsDirty] = useState(false);
+  // window.wpData is the state of things when the page was rendered; it never
+  // changes again. Keeping the builder data here instead means switching tabs
+  // shows what was just saved rather than resetting to that snapshot.
+  const [builderData, setBuilderData] = useState<Record<string, BuilderData>>(() => ({
+    gravityForms: window.wpData.gravityForms,
+    cf7: window.wpData.cf7,
+    elementor: window.wpData.elementor,
+    wpforms: window.wpData.wpforms,
+    fluentForms: window.wpData.fluentForms,
+  }));
   const [forms, setForms] = useState<LeadTrackrForm[]>([]);
-  const [diviProcessContactForm, setDiviProcessContactForm] = useState<boolean>(window.wpData.divi.processContactForm);
+  const [trackAll, setTrackAll] = useState<boolean>(false);
+  const [diviProcessContactForm, setDiviProcessContactForm] = useState<boolean>(
+    window.wpData.divi.processContactForm
+  );
 
   useEffect(() => {
-    if (typeof window.wpData !== "undefined") {
-      if (window.wpData.projectId) {
-        setProjectId(window.wpData.projectId);
-      }
-    } else {
+    if (typeof window.wpData === "undefined") {
       console.error("wpData is not defined");
+      return;
+    }
+    if (window.wpData.projectId) {
+      setProjectId(window.wpData.projectId);
     }
   }, []);
 
   useEffect(() => {
-    if (activeTab === "gravity-forms") {
-      setForms(window.wpData.gravityForms.forms);
+    const params = window.wpData.utmParams;
+    if (
+      params &&
+      UTM_FIELDS.some(({ key }) => params[key] !== DEFAULT_UTM[key])
+    ) {
+      setShowCustomUtm(true);
     }
+  }, []);
 
-    if (activeTab === "contact-form-7") {
-      setForms(window.wpData.cf7.forms);
+  useEffect(() => {
+    const builder = builderOf(activeTab);
+    if (builder) {
+      setForms(builderData[builder.key].forms);
+      setTrackAll(builderData[builder.key].trackAll);
     }
-
-    if (activeTab === "elementor") {
-      setForms(window.wpData.elementor.forms);
-    }
-
-    if (activeTab === "wpforms") {
-      setForms(window.wpData.wpforms.forms);
-    }
-
-    if (activeTab === "fluent-forms") {
-      setForms(window.wpData.fluentForms.forms);
-    }
-
-    if (activeTab === 'divi') {
+    if (activeTab === "divi") {
       setForms([]);
     }
-  }, [activeTab]);
+    setFormsDirty(false);
+  }, [activeTab, builderData]);
 
-  const onSaveProjectId = async () => {
-    setLoading(true);
-    const response = await fetch(`${window.wpData.apiUrl}/project-id`, {
+  // The LeadBot posts client-side and only needs a project. The connection as a
+  // whole is not complete until the token is there too.
+  const hasProject = Boolean(projectId);
+  // Sites that upgraded into this version keep working without a token; only
+  // new installs must supply one.
+  const tokenRequired = bool(window.wpData.apiTokenRequired);
+  const connected = hasProject && (apiTokenSet || !tokenRequired);
+
+  const discardChanges = () => {
+    if (activeTab === "leadbot") {
+      setLeadbot(savedLeadbot);
+      return;
+    }
+    if (activeTab === "general") {
+      setProjectId(savedGeneral.projectId);
+      setChannelFlowEnabled(savedGeneral.channelFlowEnabled);
+      setUtmParams(savedGeneral.utmParams);
+      setApiToken("");
+      return;
+    }
+    window.location.reload();
+  };
+
+  const generalDirty =
+    JSON.stringify({ projectId, channelFlowEnabled, utmParams }) !== JSON.stringify(savedGeneral) ||
+    apiToken !== "";
+  const leadbotDirty = JSON.stringify(leadbot) !== JSON.stringify(savedLeadbot);
+  const dirty =
+    activeTab === "general"
+      ? generalDirty
+      : activeTab === "leadbot"
+      ? leadbotDirty
+      : connected && formsDirty;
+
+  // Closing or reloading with unsaved changes now costs a browser confirm
+  // rather than the edits silently disappearing.
+  // Set just before a reload the page triggers itself, so the visitor is not
+  // asked to confirm leaving a page that is deliberately reloading.
+  const reloadingOnPurpose = useRef(false);
+
+  useEffect(() => {
+    if (!dirty) return;
+    const warn = (event: BeforeUnloadEvent) => {
+      if (reloadingOnPurpose.current) return;
+      event.preventDefault();
+    };
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [dirty]);
+
+  // The LeadBot boots once per document and guards against a second boot, so a
+  // live preview needs a fresh document per change — hence an iframe that is
+  // rewritten instead of a component that re-renders. Debounced so typing does
+  // not reload it on every keystroke.
+  const [previewOf, setPreviewOf] = useState<LeadBotSettings>(leadbot);
+  useEffect(() => {
+    const timer = setTimeout(() => setPreviewOf(leadbot), 400);
+    return () => clearTimeout(timer);
+  }, [leadbot]);
+
+  const previewDoc = useMemo(() => {
+    const config: Record<string, unknown> = {
+      projectId: projectId || "preview",
+      // Never the real API: submitting the preview form must not create a lead.
+      endpoint: window.wpData.leadbotPreviewEndpoint,
+    };
+    const copy = (key: keyof LeadBotSettings, as = key as string) => {
+      const value = previewOf[key];
+      if (value !== "" && value !== undefined) config[as] = value;
+    };
+    (["companyName", "agentName", "agentPhoto", "greeting", "phone", "whatsapp"] as const).forEach(
+      (key) => copy(key)
+    );
+    config.launcher = previewOf.launcher;
+    config.teaser = previewOf.teaser;
+    config.whatsappPhoneQuestion = previewOf.whatsappPhoneQuestion;
+    config.position = previewOf.position;
+    config.offset = { bottom: previewOf.offsetBottom, side: previewOf.offsetSide };
+    if (previewOf.language !== "auto") config.language = previewOf.language;
+    if (previewOf.responseTimeText) config.responseTimeText = previewOf.responseTimeText;
+    const theme: Record<string, unknown> = { radius: previewOf.themeRadius };
+    if (previewOf.themePrimary) theme.primary = previewOf.themePrimary;
+    if (previewOf.themePrimaryHover) theme.primaryHover = previewOf.themePrimaryHover;
+    config.theme = theme;
+
+    return `<!doctype html><html lang="${previewOf.language === "auto" ? "nl" : previewOf.language}">
+<head><meta charset="utf-8"><style>
+html,body{height:100%;margin:0;background:#f0f0f1;font-family:system-ui,sans-serif}
+.hint{padding:16px 20px;color:#8c8f94;font-size:12px;line-height:1.6}
+</style></head>
+<body><p class="hint">Preview — this is a sandbox. Anything you submit here is discarded.</p>
+<script>window.ltLeadBotConfig=${JSON.stringify(config)};<\/script>
+<script src="${window.wpData.leadbotSrc}" async><\/script>
+</body></html>`;
+  }, [previewOf, projectId]);
+
+  const notify = (ok: boolean, what: string) =>
+    toast(
+      ok
+        ? { title: `${what} saved`, description: "Your changes are live.", variant: "default" }
+        : {
+            title: `Could not save ${what.toLowerCase()}`,
+            description: "Something went wrong. Please try again.",
+            variant: "destructive",
+          }
+    );
+
+  const post = (path: string, body: unknown) =>
+    fetch(`${window.wpData.apiUrl}/${path}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        // WordPress only honours the login cookie on the REST API when this
+        // nonce comes with it. Without the header every save is rejected as
+        // rest_forbidden, no matter who is logged in.
+        "X-WP-Nonce": window.wpData.nonce,
       },
       credentials: "include",
-      body: JSON.stringify({ project_id: projectId }),
+      body: JSON.stringify(body),
     });
 
-    if (response.ok) {
-      toast({
-        title: "Project ID saved",
-        description: "Project ID has been saved successfully",
-        variant: "default",
-      });
-    } else {
-      toast({
-        title: "Failed to save project ID",
-        description: "Something went wrong",
-        variant: "destructive",
-      });
+  const onSaveGeneral = async () => {
+    setLoading(true);
+
+    const requests = [
+      post("project-id", { project_id: projectId }),
+      post("channelflow-settings", { enabled: channelFlowEnabled, utmParams }),
+    ];
+
+    // The stored token is never sent to the browser, so the field starts empty
+    // even when one is saved. Only post it when something was actually typed,
+    // otherwise saving any other setting would wipe the token.
+    if (apiToken) {
+      requests.push(post("api-token", { api_token: apiToken }));
     }
 
+    const responses = await Promise.all(requests);
+    const ok = responses.every((response) => response.ok);
+    if (ok) {
+      if (apiToken) setApiTokenSet(true);
+      setApiToken("");
+      setSavedGeneral({ projectId, channelFlowEnabled, utmParams });
+    }
+    notify(ok, "Settings");
+    setLoading(false);
+  };
+
+  const onSaveLeadBot = async () => {
+    setLoading(true);
+    const response = await post("leadbot", { leadbot });
+    if (response.ok) setSavedLeadbot(leadbot);
+    notify(response.ok, "LeadBot settings");
     setLoading(false);
   };
 
   const onSaveForms = async () => {
     setLoading(true);
 
-    const data = activeTab === 'divi' ? {
-      processContactForm: diviProcessContactForm
-    } : {
-      forms: structuredClone(forms).map((f) => {
-        delete f.title;
+    const data =
+      activeTab === "divi"
+        ? { processContactForm: diviProcessContactForm }
+        : {
+            forms: structuredClone(forms).map((f) => {
+              delete f.title;
+              return f;
+            }),
+          };
 
-        return f;
-      }),
+    const requests: Promise<Response>[] = [post(activeTab, data)];
+
+    if (activeTab !== "divi") {
+      requests.push(post("track-all", { builder: activeTab, enabled: trackAll }));
     }
 
-    const response = await fetch(`${window.wpData.apiUrl}/${activeTab}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify(data),
-    });
-
-    if (response.ok) {
-      toast({
-        title: "Forms saved",
-        description: "The forms have been saved successfully",
-        variant: "default",
-      });
-    } else {
-      toast({
-        title: "Failed to save forms",
-        description: "Something went wrong",
-        variant: "destructive",
-      });
+    const responses = await Promise.all(requests);
+    const ok = responses.every((r) => r.ok);
+    if (ok) {
+      setFormsDirty(false);
+      const builder = builderOf(activeTab);
+      if (builder) {
+        setBuilderData((current) => ({
+          ...current,
+          [builder.key]: { ...current[builder.key], forms, trackAll },
+        }));
+      }
     }
-
+    notify(ok, "Forms");
     setLoading(false);
   };
 
-  const formsContent = activeTab === 'divi' ? (
-    <>
-      <div className="flex items-center gap-12 py-2 w-1/2">
-        <Label className="w-1/2">Process Contact Form submissions</Label>
-        <Input
-          id={`process-contact-form`}
-          type="checkbox"
-          className="w-1/2"
-          checked={diviProcessContactForm}
-          onChange={(event) => {
-            setDiviProcessContactForm(event.target.checked);
+  const setBot = <K extends keyof LeadBotSettings>(key: K, value: LeadBotSettings[K]) =>
+    setLeadbot((current) => ({ ...current, [key]: value }));
+
+
+  const formsContent = (() => {
+    // Turning a form on before the connection is complete would send every
+    // submission into a rejected request, so the choice is not offered yet.
+    if (!connected) {
+      return (
+        <EmptyState title="Finish the connection first">
+          {tokenRequired
+            ? "Add your Project ID and API token under General before choosing which forms to track. Until both are set, nothing can be sent to LeadTrackr."
+            : "Add your Project ID under General before choosing which forms to track. Nothing can be sent to LeadTrackr until it is set."}
+          <span className="mt-3 block">
+            <Button variant="outline" onClick={() => setActiveTab("general")}>
+              Go to General
+            </Button>
+          </span>
+        </EmptyState>
+      );
+    }
+
+    if (!isBuilderEnabled(activeTab)) {
+      const label = activeTab === "divi" ? "Divi" : builderOf(activeTab)?.label;
+      return (
+        <EmptyState title={`${label} was not found on this site`}>
+          Install and activate {label} and this tab will fill itself with your forms. Nothing
+          is broken — there is simply nothing to configure yet.
+        </EmptyState>
+      );
+    }
+
+    if (activeTab === "divi") {
+      return (
+        <Section
+          title="Divi Contact Form"
+          description="Divi has no per-form settings, so this is a single switch for every Divi contact form on the site."
+        >
+          <ToggleField
+            id="process-contact-form"
+            label="Send Divi Contact Form submissions to LeadTrackr"
+            checked={diviProcessContactForm}
+            onChange={(checked) => {
+              setFormsDirty(true);
+              setDiviProcessContactForm(checked);
+            }}
+          />
+        </Section>
+      );
+    }
+
+    const label = builderOf(activeTab)?.label;
+
+    return (
+      <Section
+        title={`${label} forms`}
+        description="Pick which forms create a lead in LeadTrackr. A custom name replaces the form title in your reports."
+      >
+        <ToggleField
+          id="track-all-forms"
+          label="Track every form automatically"
+          hint="Includes forms you add later. Turn this off to choose per form."
+          checked={trackAll}
+          onChange={(enabled) => {
+            setTrackAll(enabled);
+            setFormsDirty(true);
           }}
         />
-      </div>
-    </>
-  ) : (
-    <>
-      <div className="flex items-center gap-12 border-b py-2">
-        <Label className="w-1/6">ID</Label>
-        <Label className="w-1/6">Form title</Label>
-        <Label className="w-1/6">Custom form name</Label>
-        <Label className="w-1/6">Send to LeadTrackr</Label>
-      </div>
-      {forms.length > 0 ? (
-        forms.map((form) => (
-          <div
-            key={`${activeTab}-${form.id}`}
-            className="flex items-center gap-12 border-b py-2"
-          >
-            <Label className="w-1/6">{form.id}</Label>
-            <Label className="font-light w-1/6">{form.title}</Label>
-            <Input
-              id={`custom-name-${form.id}`}
-              type="text"
-              className="w-1/6"
-              value={form.customTitle}
-              onChange={(event) => {
-                setForms(
-                  forms.map((f) =>
-                    f.id === form.id
-                      ? { ...f, customTitle: event.target.value }
-                      : f
-                  )
-                );
-              }}
-            />
-            <Input
-              id={`send-to-leadtrackr-${form.id}`}
-              type="checkbox"
-              className="w-1/6"
-              checked={form.sendToLeadTrackr}
-              onChange={(event) => {
-                setForms(
-                  forms.map((f) =>
-                    f.id === form.id
-                      ? { ...f, sendToLeadTrackr: event.target.checked }
-                      : f
-                  )
-                );
-              }}
-            />
+
+        {!trackAll && (
+          <div className="mt-5 overflow-hidden rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left">
+                <tr>
+                  <th className="px-4 py-2.5 font-medium w-20">ID</th>
+                  <th className="px-4 py-2.5 font-medium">Form</th>
+                  <th className="px-4 py-2.5 font-medium w-64">Custom name</th>
+                  <th className="px-4 py-2.5 font-medium w-32">Send</th>
+                </tr>
+              </thead>
+              <tbody>
+                {forms.length > 0 ? (
+                  forms.map((form) => (
+                    <tr key={`${activeTab}-${form.id}`} className="border-t border-border">
+                      <td className="px-4 py-2.5 text-muted-foreground">{form.id}</td>
+                      <td className="px-4 py-2.5">{form.title}</td>
+                      <td className="px-4 py-2.5">
+                        <Input
+                          id={`custom-name-${form.id}`}
+                          type="text"
+                          placeholder={form.title}
+                          value={form.customTitle}
+                          onChange={(event) => {
+                            setFormsDirty(true);
+                            setForms(
+                              forms.map((f) =>
+                                f.id === form.id ? { ...f, customTitle: event.target.value } : f
+                              )
+                            );
+                          }}
+                        />
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <Switch
+                          id={`send-to-leadtrackr-${form.id}`}
+                          aria-label={`Send ${form.title} to LeadTrackr`}
+                          checked={Boolean(form.sendToLeadTrackr)}
+                          onCheckedChange={(checked) => {
+                            setFormsDirty(true);
+                            setForms(
+                              forms.map((f) =>
+                                f.id === form.id ? { ...f, sendToLeadTrackr: checked } : f
+                              )
+                            );
+                          }}
+                        />
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
+                      No forms found in {label} yet.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
-        ))
-      ) : (
-        <p>No GravityForms found</p>
-      )}
-    </>
-  );
+        )}
+      </Section>
+    );
+  })();
 
   return (
-    <div style={{ width: "90%", margin: "auto" }} className="sm:py-8">
-      <img
-        src={logoSvg}
-        className="h-7 text-3xl font-semibold tracking-tight mb-4"
-        alt="LeadTrackr"
-      />
-      <Tabs
-        value={activeTab}
-        onValueChange={(tab) => {
-          setActiveTab(tab);
-        }}
-      >
+    <div className="mx-auto max-w-5xl py-8 pr-8">
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <img src={logoSvg} className="h-7" alt="LeadTrackr" />
+          <span
+            className={
+              "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm " +
+              (connected
+                ? "border-primary_branding/30 bg-primary_branding/10 text-primary_branding"
+                : "border-border bg-muted text-muted-foreground")
+            }
+          >
+            <span
+              className={
+                "h-2 w-2 rounded-full " + (connected ? "bg-primary_branding" : "bg-muted-foreground")
+              }
+              aria-hidden="true"
+            />
+            {connected
+              ? `Connected · project ${projectId}`
+              : hasProject
+              ? "Incomplete · API token missing"
+              : "Not connected"}
+          </span>
+        </div>
+        <div className="flex items-center gap-5 text-sm">
+          <ExternalLink href={links.dashboard}>Open dashboard</ExternalLink>
+          <ExternalLink href={links.docs.wordpress}>Documentation</ExternalLink>
+        </div>
+      </header>
+
+      {!connected && (
+        <div className="mb-6 rounded-lg border border-border bg-muted/40 p-4 text-sm">
+          <p className="font-medium">
+            {hasProject
+              ? "Add your API token to finish the setup"
+              : "Add your Project ID and API token to start collecting leads"}
+          </p>
+          <p className="text-muted-foreground mt-1">
+            {hasProject ? (
+              <>
+                Your project is set, but leads are still being sent without authentication.{" "}
+                <ExternalLink href={links.docs.apiToken}>Where to find your token</ExternalLink>
+              </>
+            ) : (
+              <>
+                You will find both under Projects in your LeadTrackr dashboard. No leads are
+                sent until the Project ID is filled in.{" "}
+                <ExternalLink href={links.docs.createProject}>How to create a project</ExternalLink>
+              </>
+            )}
+          </p>
+        </div>
+      )}
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList>
-          <TabsTrigger value="general">Project general</TabsTrigger>
-          <TabsTrigger
-            disabled={!window.wpData.gravityForms.enabled}
-            value="gravity-forms"
-          >
-            GravityForms
-          </TabsTrigger>
-          <TabsTrigger
-            disabled={!window.wpData.cf7.enabled}
-            value="contact-form-7"
-          >
-            Contact Form 7
-          </TabsTrigger>
-          <TabsTrigger
-            disabled={!window.wpData.elementor.enabled}
-            value="elementor"
-          >
-            Elementor
-          </TabsTrigger>
-          <TabsTrigger
-            disabled={!window.wpData.wpforms.enabled}
-            value="wpforms"
-          >
-            WPForms
-          </TabsTrigger>
-          <TabsTrigger
-            disabled={!window.wpData.fluentForms.enabled}
-            value="fluent-forms"
-          >
-            Fluent Forms
-          </TabsTrigger>
-          <TabsTrigger
-            // disabled={!window.wpData.divi.enabled}
-            value="divi"
-          >
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="leadbot">LeadBot</TabsTrigger>
+          {BUILDERS.map((builder) => (
+            <TabsTrigger
+              key={builder.tab}
+              value={builder.tab}
+              disabled={!window.wpData[builder.key].enabled}
+            >
+              {builder.label}
+            </TabsTrigger>
+          ))}
+          <TabsTrigger value="divi" disabled={!window.wpData.divi.enabled}>
             Divi
           </TabsTrigger>
         </TabsList>
 
-        <div className="mt-2">
+        <div className="mt-4">
           <TabsContent value="general">
-            <div className="w-2/6">
-              <Label className="block mb-2" htmlFor="project-id">
-                Project ID
-              </Label>
-              <Input
-                value={projectId}
-                onChange={(event) => setProjectId(event.target.value)}
-                name="project-id"
-                id="project-id"
-              />
-            </div>
-            <Button
-              onClick={() => {
-                onSaveProjectId();
-              }}
-              disabled={loading}
-              className="mt-2"
+            <Section
+              title="Connection"
+              description="Where this site sends its leads."
             >
-              {loading ? "Saving..." : "Save"}
-            </Button>
+              <div className="space-y-5">
+                <Field
+                  label="Project ID"
+                  htmlFor="project-id"
+                  hint={
+                    <>
+                      Find it under Projects in your dashboard.{" "}
+                      <ExternalLink href={links.projects}>Open Projects</ExternalLink>
+                    </>
+                  }
+                >
+                  <Input
+                    id="project-id"
+                    name="project-id"
+                    type="text"
+                    value={projectId}
+                    onChange={(event) => setProjectId(event.target.value)}
+                  />
+                </Field>
+
+                <Field
+                  label="API Token"
+                  htmlFor="api-token"
+                  badge={apiTokenSet || !tokenRequired ? undefined : "Required"}
+                  hint={
+                    <>
+                      Authenticates this site and sends leads server-side.{" "}
+                      <ExternalLink href={links.docs.apiToken}>Where to find your token</ExternalLink>
+                    </>
+                  }
+                >
+                  <Input
+                    id="api-token"
+                    name="api-token"
+                    type="password"
+                    autoComplete="off"
+                    value={apiToken}
+                    placeholder={apiTokenSet ? "Saved — type a new token to replace it" : ""}
+                    onChange={(event) => setApiToken(event.target.value)}
+                  />
+                </Field>
+              </div>
+            </Section>
+
+            <Section
+              title="Channel Flow"
+              description={
+                <>
+                  Records the visitor's marketing journey — one entry per session, with the
+                  source, campaign and landing page — and attaches it to every lead.{" "}
+                  <ExternalLink href={links.docs.channelFlow}>How Channel Flow works</ExternalLink>
+                </>
+              }
+            >
+              <div className="space-y-5">
+                <ToggleField
+                  id="channelflow-enabled"
+                  label="Enable Channel Flow tracking"
+                  hint="See which channels every lead went through before converting, from the first visit to the form they filled in."
+                  checked={channelFlowEnabled}
+                  onChange={setChannelFlowEnabled}
+                />
+
+                {channelFlowEnabled && (
+                  <>
+                    <ToggleField
+                      id="custom-utm"
+                      label="Use custom UTM parameter names"
+                      hint="Only needed if your ads use something other than utm_source and friends."
+                      checked={showCustomUtm}
+                      onChange={(checked) => {
+                        setShowCustomUtm(checked);
+                        if (!checked) setUtmParams(DEFAULT_UTM);
+                      }}
+                    />
+
+                    {showCustomUtm && (
+                      <div className="ml-7 space-y-4 border-l border-border pl-5">
+                        {UTM_FIELDS.map(({ key, label }) => (
+                          <Field key={key} label={label} htmlFor={`utm-${key}`}>
+                            <Input
+                              id={`utm-${key}`}
+                              type="text"
+                              value={utmParams[key]}
+                              placeholder={DEFAULT_UTM[key]}
+                              onChange={(event) =>
+                                setUtmParams({ ...utmParams, [key]: event.target.value })
+                              }
+                            />
+                          </Field>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            </Section>
+
           </TabsContent>
-          <TabsContent value="gravity-forms">{formsContent}</TabsContent>
-          <TabsContent value="contact-form-7">{formsContent}</TabsContent>
-          <TabsContent value="elementor">{formsContent}</TabsContent>
-          <TabsContent value="wpforms">{formsContent}</TabsContent>
-          <TabsContent value="fluent-forms">{formsContent}</TabsContent>
-          <TabsContent value="divi">{formsContent}</TabsContent>
-          {activeTab !== "general" && (
-            <Button disabled={loading} onClick={onSaveForms} className="mt-2">
-              {loading ? "Saving..." : "Save"}
-            </Button>
-          )}
+
+          <TabsContent value="leadbot">
+            <Section
+              title="LeadBot"
+              description={
+                <>
+                  A contact launcher in the corner of your site: message, phone and WhatsApp,
+                  with every conversation landing in LeadTrackr with full attribution. The
+                  script is only loaded when this is switched on.{" "}
+                  <ExternalLink href={links.docs.wordpress}>Documentation</ExternalLink>
+                </>
+              }
+            >
+              <ToggleField
+                id="leadbot-enabled"
+                label="Enable the LeadBot on this site"
+                hint={
+                  hasProject
+                    ? "Loads roughly 18 KB, after the page has rendered."
+                    : "Fill in your Project ID first — the LeadBot needs it to send leads."
+                }
+                checked={leadbot.enabled}
+                onChange={(checked) => setBot("enabled", checked)}
+                disabled={!hasProject}
+              />
+            </Section>
+
+            {leadbot.enabled && (
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_380px]">
+                <div>
+                <Section
+                  title="Who is talking"
+                  description="Shown at the top of the panel. Naming an agent makes the LeadBot speak as “I” instead of “we”."
+                >
+                  <div className="space-y-5">
+                    <Field label="Company name" htmlFor="lb-company">
+                      <Input
+                        id="lb-company"
+                        type="text"
+                        value={leadbot.companyName}
+                        onChange={(e) => setBot("companyName", e.target.value)}
+                      />
+                    </Field>
+                    <Field label="Agent name" htmlFor="lb-agent" badge="Optional">
+                      <Input
+                        id="lb-agent"
+                        type="text"
+                        value={leadbot.agentName}
+                        onChange={(e) => setBot("agentName", e.target.value)}
+                      />
+                    </Field>
+                    <Field
+                      label="Agent photo"
+                      htmlFor="lb-agent-photo"
+                      badge="Optional"
+                      hint="Full URL to a square image."
+                    >
+                      <Input
+                        id="lb-agent-photo"
+                        type="url"
+                        value={leadbot.agentPhoto}
+                        onChange={(e) => setBot("agentPhoto", e.target.value)}
+                      />
+                    </Field>
+                    <Field
+                      label="Greeting"
+                      htmlFor="lb-greeting"
+                      badge="Optional"
+                      hint="Leave empty to use the built-in greeting for the visitor's language."
+                    >
+                      <Input
+                        id="lb-greeting"
+                        type="text"
+                        value={leadbot.greeting}
+                        onChange={(e) => setBot("greeting", e.target.value)}
+                      />
+                    </Field>
+                    <Field
+                      label="Response time"
+                      htmlFor="lb-response-time"
+                      badge="Optional"
+                      hint="For example: Average response time: within 15 minutes."
+                    >
+                      <Input
+                        id="lb-response-time"
+                        type="text"
+                        value={leadbot.responseTimeText}
+                        onChange={(e) => setBot("responseTimeText", e.target.value)}
+                      />
+                    </Field>
+                  </div>
+                </Section>
+
+                <Section
+                  title="Channels"
+                  description="A channel only appears when you fill in its details. Leave both empty for a message-only LeadBot."
+                >
+                  <div className="space-y-5">
+                    <Field
+                      label="Phone number"
+                      htmlFor="lb-phone"
+                      badge="Optional"
+                      hint="Shown as a call button."
+                    >
+                      <Input
+                        id="lb-phone"
+                        type="tel"
+                        value={leadbot.phone}
+                        onChange={(e) => setBot("phone", e.target.value)}
+                      />
+                    </Field>
+                    <Field
+                      label="WhatsApp number"
+                      htmlFor="lb-whatsapp"
+                      badge="Optional"
+                      hint="International format, for example +31612345678."
+                    >
+                      <Input
+                        id="lb-whatsapp"
+                        type="tel"
+                        value={leadbot.whatsapp}
+                        onChange={(e) => setBot("whatsapp", e.target.value)}
+                      />
+                    </Field>
+
+                    <ToggleField
+                      id="lb-call-tracking"
+                      label="Activate YesWeTrack call tracking in the LeadBot"
+                      hint="Shows the dynamically inserted YesWeTrack number instead of the one above, for both the displayed number and the call link. Only useful on sites that already run YesWeTrack call tracking."
+                      checked={leadbot.callTracking}
+                      onChange={(checked) => setBot("callTracking", checked)}
+                    />
+                    <ToggleField
+                      id="lb-wa-interceptor"
+                      label="Intercept existing WhatsApp links"
+                      hint="Clicks on wa.me links already on your pages open the LeadBot first, so the conversation is captured as a lead."
+                      checked={leadbot.whatsappInterceptor}
+                      onChange={(checked) => setBot("whatsappInterceptor", checked)}
+                    />
+                    <ToggleField
+                      id="lb-wa-phone-question"
+                      label="Ask for a phone number in the WhatsApp flow"
+                      hint="Turn off to send visitors straight through to WhatsApp. The lead still arrives, without a phone number."
+                      checked={leadbot.whatsappPhoneQuestion}
+                      onChange={(checked) => setBot("whatsappPhoneQuestion", checked)}
+                    />
+                  </div>
+                </Section>
+
+                <Section title="Appearance">
+                  <div className="space-y-5">
+                    <Field label="Corner" htmlFor="lb-position">
+                      <select
+                        id="lb-position"
+                        className="w-full"
+                        value={leadbot.position}
+                        onChange={(e) => setBot("position", e.target.value as "right" | "left")}
+                      >
+                        <option value="right">Bottom right</option>
+                        <option value="left">Bottom left</option>
+                      </select>
+                    </Field>
+
+                    <div className="flex gap-4">
+                      <Field label="Distance from bottom" htmlFor="lb-offset-bottom">
+                        <Input
+                          id="lb-offset-bottom"
+                          type="number"
+                          value={leadbot.offsetBottom}
+                          onChange={(e) => setBot("offsetBottom", Number(e.target.value))}
+                        />
+                      </Field>
+                      <Field label="Distance from the side" htmlFor="lb-offset-side">
+                        <Input
+                          id="lb-offset-side"
+                          type="number"
+                          value={leadbot.offsetSide}
+                          onChange={(e) => setBot("offsetSide", Number(e.target.value))}
+                        />
+                      </Field>
+                    </div>
+
+                    <Field label="Language" htmlFor="lb-language">
+                      <select
+                        id="lb-language"
+                        className="w-full"
+                        value={leadbot.language}
+                        onChange={(e) =>
+                          setBot("language", e.target.value as "auto" | "nl" | "en")
+                        }
+                      >
+                        <option value="auto">Follow the page language</option>
+                        <option value="nl">Nederlands</option>
+                        <option value="en">English</option>
+                      </select>
+                    </Field>
+
+                    <Field
+                      label="Brand colour"
+                      htmlFor="lb-primary"
+                      badge="Optional"
+                      hint="Leave empty to keep the LeadTrackr green."
+                    >
+                      <div className="flex items-center gap-3">
+                        <input
+                          id="lb-primary"
+                          type="color"
+                          value={leadbot.themePrimary || "#52b483"}
+                          onChange={(e) => setBot("themePrimary", e.target.value)}
+                        />
+                        <Input
+                          type="text"
+                          aria-label="Brand colour hex"
+                          placeholder="#52b483"
+                          value={leadbot.themePrimary}
+                          onChange={(e) => setBot("themePrimary", e.target.value)}
+                        />
+                      </div>
+                    </Field>
+
+                    <Field
+                      label="Hover colour"
+                      htmlFor="lb-primary-hover"
+                      badge="Optional"
+                      hint="A slightly darker shade of your brand colour."
+                    >
+                      <div className="flex items-center gap-3">
+                        <input
+                          id="lb-primary-hover"
+                          type="color"
+                          value={leadbot.themePrimaryHover || "#3e8762"}
+                          onChange={(e) => setBot("themePrimaryHover", e.target.value)}
+                        />
+                        <Input
+                          type="text"
+                          aria-label="Hover colour hex"
+                          placeholder="#3e8762"
+                          value={leadbot.themePrimaryHover}
+                          onChange={(e) => setBot("themePrimaryHover", e.target.value)}
+                        />
+                      </div>
+                    </Field>
+
+                    <Field label="Corner rounding" htmlFor="lb-radius">
+                      <Input
+                        id="lb-radius"
+                        type="number"
+                        value={leadbot.themeRadius}
+                        onChange={(e) => setBot("themeRadius", Number(e.target.value))}
+                      />
+                    </Field>
+
+                    <ToggleField
+                      id="lb-teaser"
+                      label="Show the teaser bubble"
+                      hint="The short message that appears next to the launcher."
+                      checked={leadbot.teaser}
+                      onChange={(checked) => setBot("teaser", checked)}
+                    />
+                    <ToggleField
+                      id="lb-launcher"
+                      label="Show the launcher button"
+                      hint="Turn off to hide the button entirely and only use the WhatsApp interception above."
+                      checked={leadbot.launcher}
+                      onChange={(checked) => setBot("launcher", checked)}
+                    />
+                  </div>
+                </Section>
+                </div>
+
+                <aside className="lg:sticky lg:top-8 self-start">
+                  <Section
+                    title="Live preview"
+                    description="Your changes appear here a moment after you make them. Submissions in this preview are discarded — no lead is created."
+                  >
+                    <iframe
+                      title="LeadBot preview"
+                      srcDoc={previewDoc}
+                      sandbox="allow-scripts allow-same-origin allow-popups"
+                      className="h-[520px] w-full rounded-md border border-border bg-white"
+                    />
+                  </Section>
+                </aside>
+              </div>
+            )}
+
+          </TabsContent>
+
+          {[...BUILDERS.map((b) => b.tab), "divi"].map((tab) => (
+            <TabsContent key={tab} value={tab}>
+              {formsContent}
+            </TabsContent>
+          ))}
         </div>
       </Tabs>
+
+      {/* Sits above everything and only appears once something changed, so the
+          page can never look finished while an edit is still unsaved. */}
+      {dirty && (
+        <div className="sticky bottom-4 z-20 mt-3 flex items-center justify-between gap-4 rounded-xl border bg-card px-5 py-3 shadow-lg">
+          <p className="text-sm font-medium">You have unsaved changes</p>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" disabled={loading} onClick={discardChanges}>
+              Discard
+            </Button>
+            <Button
+              disabled={loading}
+              onClick={
+                activeTab === "general"
+                  ? onSaveGeneral
+                  : activeTab === "leadbot"
+                  ? onSaveLeadBot
+                  : onSaveForms
+              }
+            >
+              {loading ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary_branding text-primary-foreground hover:bg-primary_brandingd/90",
+        default: "bg-primary_branding text-primary-foreground hover:bg-primary_branding/90",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:

--- a/app/src/components/ui/section.tsx
+++ b/app/src/components/ui/section.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+import { Switch } from "./switch";
+
+/**
+ * A titled block of settings. Groups related fields so the page reads as a few
+ * decisions instead of one long column of inputs.
+ */
+export function Section({
+  title,
+  description,
+  children,
+  className,
+}: {
+  title: string;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={cn("rounded-xl border bg-card p-5 shadow-sm mb-3", className)}>
+      <h2 className="text-base font-semibold leading-none">{title}</h2>
+      {description && <p className="text-sm text-muted-foreground mt-1.5">{description}</p>}
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+/**
+ * A labelled field with room for the one sentence that explains what the value
+ * is for. Keeps every field on the page built the same way.
+ */
+export function Field({
+  label,
+  htmlFor,
+  hint,
+  badge,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  hint?: React.ReactNode;
+  badge?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="max-w-md">
+      <div className="flex items-center gap-2 mb-1.5">
+        <label
+          htmlFor={htmlFor}
+          className="text-sm font-medium leading-none"
+        >
+          {label}
+        </label>
+        {badge && (
+          <span className="rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+            {badge}
+          </span>
+        )}
+      </div>
+      {children}
+      {hint && <p className="text-sm text-muted-foreground mt-1.5">{hint}</p>}
+    </div>
+  );
+}
+
+/**
+ * Switch plus label plus explanation, built once so every toggle on the page
+ * looks and behaves the same.
+ */
+export function ToggleField({
+  id,
+  label,
+  hint,
+  checked,
+  onChange,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  hint?: React.ReactNode;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className={cn("flex items-start gap-3", disabled && "opacity-50")}>
+      <Switch id={id} checked={checked} onCheckedChange={onChange} disabled={disabled} />
+      <div className="min-w-0">
+        <label
+          htmlFor={id}
+          onClick={() => !disabled && onChange(!checked)}
+          className="text-sm font-medium leading-none cursor-pointer"
+        >
+          {label}
+        </label>
+        {hint && <p className="text-sm text-muted-foreground mt-1">{hint}</p>}
+      </div>
+    </div>
+  );
+}
+
+/** External link with a consistent look and the arrow that marks "leaves WordPress". */
+export function ExternalLink({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={cn(
+        "inline-flex items-center gap-1 font-medium text-primary_branding hover:underline",
+        className
+      )}
+    >
+      {children}
+      <span aria-hidden="true">↗</span>
+    </a>
+  );
+}
+
+/** Shown where a form builder is expected but not present on the site. */
+export function EmptyState({
+  title,
+  children,
+}: {
+  title: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-dashed bg-card py-10 px-6 text-center shadow-sm">
+      <p className="text-sm font-medium">{title}</p>
+      {children && <p className="text-sm text-muted-foreground mt-1.5">{children}</p>}
+    </div>
+  );
+}

--- a/app/src/components/ui/switch.tsx
+++ b/app/src/components/ui/switch.tsx
@@ -1,0 +1,48 @@
+import { cn } from "../../lib/utils";
+
+/**
+ * The same on/off control as the LeadTrackr dashboard, rebuilt on a plain
+ * button so the plugin does not pull in @radix-ui/react-switch for one widget.
+ * Classes deliberately match the app's Switch so the two read as one product.
+ */
+export function Switch({
+  checked,
+  onCheckedChange,
+  disabled,
+  id,
+  className,
+  "aria-label": ariaLabel,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  "aria-label"?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      id={id}
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent p-0 transition-colors",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary_branding" : "bg-input",
+        className
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -109,3 +109,80 @@
 .card-hover{
   @apply transition-all duration-300 hover:shadow-md;
 }
+
+/*
+ * WordPress admin styles target inputs by their type attribute
+ * (input[type="text"], input[type="password"], …). Any field in this plugin
+ * with an explicit type was therefore being restyled by forms.css — different
+ * border, radius and padding than the fields without one. Reset those rules
+ * inside our own mount point so the plugin's design is what actually renders.
+ */
+#leadtrackr-app-settings input[type="text"],
+#leadtrackr-app-settings input[type="password"],
+#leadtrackr-app-settings input[type="url"],
+#leadtrackr-app-settings input[type="tel"],
+#leadtrackr-app-settings input[type="email"],
+#leadtrackr-app-settings input[type="number"],
+#leadtrackr-app-settings input[type="search"],
+#leadtrackr-app-settings select,
+#leadtrackr-app-settings textarea {
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius);
+  padding: 0.5rem 0.75rem;
+  min-height: 2.5rem;
+  line-height: 1.5;
+  font-size: 0.875rem;
+  color: hsl(var(--foreground));
+  background-color: hsl(var(--background));
+  box-shadow: none;
+}
+
+#leadtrackr-app-settings input[type="text"]:focus,
+#leadtrackr-app-settings input[type="password"]:focus,
+#leadtrackr-app-settings input[type="url"]:focus,
+#leadtrackr-app-settings input[type="tel"]:focus,
+#leadtrackr-app-settings input[type="email"]:focus,
+#leadtrackr-app-settings input[type="number"]:focus,
+#leadtrackr-app-settings select:focus,
+#leadtrackr-app-settings textarea:focus {
+  border-color: hsl(var(--ring));
+  box-shadow: none;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+#leadtrackr-app-settings input[type="checkbox"] {
+  border-radius: 3px;
+  box-shadow: none;
+}
+
+#leadtrackr-app-settings input[type="color"] {
+  padding: 2px;
+  min-height: 2.5rem;
+  width: 3.5rem;
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius);
+  background-color: hsl(var(--background));
+}
+
+/*
+ * WordPress draws admin checkboxes itself: appearance is stripped and the tick
+ * is a dashicon in ::before, coloured #3582c4. That wins over accent-color, so
+ * the plugin's checkboxes came out WordPress blue. Hand the rendering back to
+ * the browser and let accent-color carry the brand.
+ */
+#leadtrackr-app-settings input[type="checkbox"] {
+  appearance: auto;
+  -webkit-appearance: checkbox;
+  accent-color: #52b483;
+  background: none;
+  border: none;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  transition: none;
+}
+
+#leadtrackr-app-settings input[type="checkbox"]::before {
+  content: none;
+}

--- a/app/src/links.ts
+++ b/app/src/links.ts
@@ -1,0 +1,19 @@
+/**
+ * Every outbound link in one place, so a moved documentation page is a single
+ * edit instead of a hunt through the components.
+ */
+const APP = "https://app.leadtrackr.io";
+const DOCS = "https://leadtrackr.io/docs";
+
+export const links = {
+  dashboard: APP,
+  projects: `${APP}/dashboard/projects`,
+
+  docs: {
+    wordpress: `${DOCS}/lead-sources/wordpress-forms`,
+    createProject: `${DOCS}/getting-started/create-account-and-project`,
+    apiToken: `${DOCS}/api-reference/authentication`,
+    channelFlow: `${DOCS}/lead-sources/channel-flow-tracker`,
+    conversionLabels: `${DOCS}/conversion-labels/set-up-conversion-labels`,
+  },
+} as const;

--- a/assets/channelflow.js
+++ b/assets/channelflow.js
@@ -263,6 +263,8 @@
    * writing a guess: an absent value reads as "we don't know", and if this call
    * ever stops working the field simply goes missing instead of going wrong.
    */
+  var lastConsentWritten = null;
+
   function updateConsentState() {
     var getConsentState;
     try {
@@ -295,14 +297,20 @@
       }
     }
 
-    if (known === 0) {
+    var serialised = known === 0 ? '' : JSON.stringify(state);
+    if (serialised === lastConsentWritten) {
+      return;
+    }
+    lastConsentWritten = serialised;
+
+    if (serialised === '') {
       // Clear rather than leave a stale answer behind, for instance after gtag
       // has been removed from the site.
       setCookie(CONSENT_COOKIE, '', 0);
       return;
     }
 
-    setCookie(CONSENT_COOKIE, JSON.stringify(state), sessionTimeoutSeconds());
+    setCookie(CONSENT_COOKIE, serialised, sessionTimeoutSeconds());
   }
 
   function updateChannelFlow() {
@@ -340,4 +348,16 @@
 
   updateChannelFlow();
   updateConsentState();
+
+  // Consent is nearly always given after this script has run: the banner
+  // appears, the visitor accepts, and nothing navigates. Reading it once on
+  // pageview would therefore record the state from before they agreed. These
+  // two listeners re-read it at the moments that decide what ends up on the
+  // lead, without loading anything extra at submit time.
+  //
+  // submit runs in the capture phase so it fires before a form builder turns
+  // the submission into an AJAX call; the cookie is written synchronously and
+  // so travels with that request either way.
+  document.addEventListener('submit', updateConsentState, true);
+  document.addEventListener('pointerdown', updateConsentState, true);
 })();

--- a/assets/channelflow.js
+++ b/assets/channelflow.js
@@ -346,18 +346,42 @@
     setCookie(SESSION_COOKIE, '1', sessionTimeoutSeconds());
   }
 
-  updateChannelFlow();
-  updateConsentState();
+  /**
+   * Consent is nearly always given after this script has run: the banner
+   * appears, the visitor accepts, and nothing navigates. gtag exposes a
+   * listener for exactly this, so the cookie is rewritten the moment consent
+   * changes instead of being re-checked on every interaction.
+   *
+   * The retry is because this script sits in the head and gtag frequently
+   * arrives a moment later, when there would be nothing to register on yet.
+   */
+  function watchConsent(attemptsLeft) {
+    var ics;
+    try {
+      ics = window.google_tag_data && window.google_tag_data.ics;
+    } catch (e) {
+      return;
+    }
 
-  // Consent is nearly always given after this script has run: the banner
-  // appears, the visitor accepts, and nothing navigates. Reading it once on
-  // pageview would therefore record the state from before they agreed. These
-  // two listeners re-read it at the moments that decide what ends up on the
-  // lead, without loading anything extra at submit time.
-  //
-  // submit runs in the capture phase so it fires before a form builder turns
-  // the submission into an AJAX call; the cookie is written synchronously and
-  // so travels with that request either way.
-  document.addEventListener('submit', updateConsentState, true);
-  document.addEventListener('pointerdown', updateConsentState, true);
+    if (ics && typeof ics.addListener === 'function') {
+      updateConsentState();
+      try {
+        ics.addListener(CONSENT_TYPES, updateConsentState);
+      } catch (e) {
+        // Undocumented API: losing the listener costs updates, nothing else.
+      }
+      return;
+    }
+
+    if (attemptsLeft > 0) {
+      setTimeout(function () {
+        watchConsent(attemptsLeft - 1);
+      }, 400);
+    }
+  }
+
+  updateChannelFlow();
+  // Runs first so a stale value is cleared even when gtag never turns up.
+  updateConsentState();
+  watchConsent(10);
 })();

--- a/assets/channelflow.js
+++ b/assets/channelflow.js
@@ -14,6 +14,11 @@
 
   var COOKIE_NAME = 'lt_channelflow';
   var SESSION_COOKIE = 'lt_session';
+  var CONSENT_COOKIE = 'lt_consent';
+  var CONSENT_TYPES = ['ad_storage', 'analytics_storage', 'ad_user_data', 'ad_personalization'];
+  // Google's internal consent state codes.
+  var CONSENT_GRANTED = 1;
+  var CONSENT_DENIED = 2;
   var MAX_AGE_SECONDS = 395 * 86400;
   var DEFAULT_TIMEOUT_MINUTES = 30;
 
@@ -247,6 +252,59 @@
     return flow;
   }
 
+  /**
+   * Reads Consent Mode state from gtag's internal store and leaves it where PHP
+   * can pick it up when a form is submitted — the lead is sent server-side, so
+   * it cannot read this itself.
+   *
+   * There is no documented client-side API for this outside GTM's own template
+   * sandbox, and plenty of sites have no gtag or GTM at all. Every path that
+   * cannot produce a definite answer therefore removes the cookie rather than
+   * writing a guess: an absent value reads as "we don't know", and if this call
+   * ever stops working the field simply goes missing instead of going wrong.
+   */
+  function updateConsentState() {
+    var getConsentState;
+    try {
+      getConsentState =
+        window.google_tag_data &&
+        window.google_tag_data.ics &&
+        window.google_tag_data.ics.getConsentState;
+    } catch (e) {
+      getConsentState = null;
+    }
+
+    var state = {};
+    var known = 0;
+    if (typeof getConsentState === 'function') {
+      for (var i = 0; i < CONSENT_TYPES.length; i++) {
+        var type = CONSENT_TYPES[i];
+        var value;
+        try {
+          value = getConsentState(type);
+        } catch (e) {
+          continue;
+        }
+        if (value === CONSENT_GRANTED) {
+          state[type] = 'granted';
+          known++;
+        } else if (value === CONSENT_DENIED) {
+          state[type] = 'denied';
+          known++;
+        }
+      }
+    }
+
+    if (known === 0) {
+      // Clear rather than leave a stale answer behind, for instance after gtag
+      // has been removed from the site.
+      setCookie(CONSENT_COOKIE, '', 0);
+      return;
+    }
+
+    setCookie(CONSENT_COOKIE, JSON.stringify(state), sessionTimeoutSeconds());
+  }
+
   function updateChannelFlow() {
     var flow = readChannelFlow();
     // Truthy, not just present: a cleared cookie can linger as an empty value.
@@ -281,4 +339,5 @@
   }
 
   updateChannelFlow();
+  updateConsentState();
 })();

--- a/assets/channelflow.js
+++ b/assets/channelflow.js
@@ -1,0 +1,284 @@
+/**
+ * LeadTrackr ChannelFlow
+ *
+ * Records the visitor's marketing journey in a first-party cookie. One entry
+ * per session, not per pageview.
+ *
+ * Must stay behaviourally identical to the GTM tag (leadtrackr/gtm-leadtrackr-tag)
+ * and the LeadBot (leadtrackr/leadtrackr-leadbot): all three write the same two
+ * cookies, so any difference in format or logic means they overwrite each
+ * other's journeys. See docs/channelflow-logica.md in the tag repository.
+ */
+(function () {
+  'use strict';
+
+  var COOKIE_NAME = 'lt_channelflow';
+  var SESSION_COOKIE = 'lt_session';
+  var MAX_AGE_SECONDS = 395 * 86400;
+  var DEFAULT_TIMEOUT_MINUTES = 30;
+
+  // A entry marks the start of a session, so the array only grows for
+  // returning visitors. Both limits guard the 4KB browser cookie limit: past
+  // it the cookie is silently rejected and the whole journey is lost.
+  var MAX_ENTRIES = 25;
+  var MAX_COOKIE_LENGTH = 3500;
+
+  var SEARCH_ENGINE_LABELS = [
+    'google', 'bing', 'yahoo', 'duckduckgo', 'baidu',
+    'ecosia', 'yandex', 'startpage', 'qwant', 'brave', 'naver'
+  ];
+  var SECOND_LEVEL_DOMAINS = ['co', 'com', 'org', 'net', 'gov', 'edu', 'ac', 'mil'];
+  var GOOGLE_CLICK_IDS = ['gclid', 'gbraid', 'wbraid'];
+
+  var config = window.leadtrackrChannelFlowConfig || {};
+  var UTM_MAPPING = [
+    ['s', config.sourceParam || 'utm_source'],
+    ['m', config.mediumParam || 'utm_medium'],
+    ['cm', config.campaignParam || 'utm_campaign'],
+    ['ct', config.contentParam || 'utm_content'],
+    ['tm', config.termParam || 'utm_term']
+  ];
+
+  function sessionTimeoutSeconds() {
+    var minutes = parseInt(config.sessionTimeoutMinutes, 10);
+    if (!minutes || minutes < 1) minutes = DEFAULT_TIMEOUT_MINUTES;
+    return minutes * 60;
+  }
+
+  function getQueryParam(name) {
+    return new URLSearchParams(window.location.search).get(name) || '';
+  }
+
+  function getCookie(name) {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = cookies[i].trim();
+      if (cookie.indexOf(name + '=') === 0) {
+        return cookie.substring(name.length + 1);
+      }
+    }
+    return '';
+  }
+
+  var cachedDomain;
+
+  /**
+   * Highest domain the browser accepts a cookie on, found by probing rather
+   * than by guessing from the hostname. Counting labels gets multi-part
+   * suffixes wrong: on a .co.uk site it yields domain=.co.uk, which every
+   * browser rejects, leaving no cookie at all.
+   */
+  function cookieDomain() {
+    if (cachedDomain !== undefined) return cachedDomain;
+
+    var parts = window.location.hostname.split('.');
+    for (var i = parts.length - 2; i >= 0; i--) {
+      var candidate = parts.slice(i).join('.');
+      document.cookie = 'lt_probe=1;path=/;domain=' + candidate;
+      if (getCookie('lt_probe')) {
+        document.cookie = 'lt_probe=;path=/;domain=' + candidate + ';max-age=0';
+        cachedDomain = candidate;
+        return cachedDomain;
+      }
+    }
+    cachedDomain = null;
+    return cachedDomain;
+  }
+
+  function setCookie(name, value, maxAgeSeconds) {
+    var domain = cookieDomain();
+    document.cookie =
+      name + '=' + encodeURIComponent(value) +
+      ';path=/;max-age=' + maxAgeSeconds +
+      (domain ? ';domain=' + domain : '') +
+      ';SameSite=Lax' +
+      (window.location.protocol === 'https:' ? ';Secure' : '');
+  }
+
+  /**
+   * Registrable part of a host: www.google.nl -> google.nl,
+   * www.google.co.uk -> google.co.uk. Matching on this instead of the full
+   * host is what makes every country domain resolve to the same search engine.
+   */
+  function registrableDomain(host) {
+    if (!host) return '';
+    var parts = host.split('.');
+    if (parts.length <= 2) return host;
+
+    var take = SECOND_LEVEL_DOMAINS.indexOf(parts[parts.length - 2]) > -1 ? 3 : 2;
+    if (parts.length <= take) return host;
+    return parts.slice(parts.length - take).join('.');
+  }
+
+  function domainLabel(host) {
+    var registrable = registrableDomain(host);
+    return registrable ? registrable.split('.')[0] : '';
+  }
+
+  function referrerHost() {
+    if (!document.referrer) return '';
+    try {
+      return new URL(document.referrer).hostname;
+    } catch (e) {
+      return '';
+    }
+  }
+
+  // An empty referrer is not internal: a real ad click can arrive without one.
+  function isInternalReferrer() {
+    var referrer = referrerHost();
+    if (!referrer) return false;
+    return registrableDomain(referrer) === registrableDomain(window.location.hostname);
+  }
+
+  function utmChannel() {
+    var channel = {};
+    var hasAny = false;
+
+    for (var i = 0; i < UTM_MAPPING.length; i++) {
+      var value = getQueryParam(UTM_MAPPING[i][1]);
+      if (value) {
+        channel[UTM_MAPPING[i][0]] = value;
+        hasAny = true;
+      }
+    }
+    if (!hasAny) return null;
+
+    if (!channel.s) channel.s = '(not set)';
+    if (!channel.m) channel.m = '(not set)';
+    return channel;
+  }
+
+  // Click IDs count only when present in this pageview's query string. Reading
+  // them from _gcl_aw would mark every later visit as paid for 90 days.
+  function clickIdChannel() {
+    for (var i = 0; i < GOOGLE_CLICK_IDS.length; i++) {
+      if (getQueryParam(GOOGLE_CLICK_IDS[i])) return { s: 'google', m: 'cpc' };
+    }
+    if (getQueryParam('msclkid')) return { s: 'bing', m: 'cpc' };
+    return null;
+  }
+
+  function resolveChannel(utm, clickId) {
+    if (utm) return utm;
+    if (clickId) return clickId;
+
+    var referrer = referrerHost();
+    // Compared on domain level so a hop between subdomains stays internal.
+    if (referrer && registrableDomain(referrer) !== registrableDomain(window.location.hostname)) {
+      var label = domainLabel(referrer);
+      if (SEARCH_ENGINE_LABELS.indexOf(label) > -1) return { s: label, m: 'organic' };
+      return { s: referrer, m: 'referral' };
+    }
+
+    return { s: 'direct', m: 'none' };
+  }
+
+  function sameChannel(a, b) {
+    if (!a || !b) return false;
+    var keys = ['s', 'm', 'cm', 'ct', 'tm'];
+    for (var i = 0; i < keys.length; i++) {
+      if ((a[keys[i]] || '') !== (b[keys[i]] || '')) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Accepts both the compact format and the original one still living in
+   * cookies out in the field, so existing journeys survive the upgrade.
+   */
+  function toCompactEntry(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+
+    if (typeof entry.t === 'number' && entry.ch && typeof entry.ch === 'object') {
+      return entry;
+    }
+    if (typeof entry.timestamp === 'number' && entry.channel && typeof entry.channel === 'object') {
+      var legacy = entry.channel;
+      var channel = {};
+      if (legacy.source) channel.s = legacy.source;
+      if (legacy.medium) channel.m = legacy.medium;
+      if (legacy.campaign) channel.cm = legacy.campaign;
+      if (legacy.content) channel.ct = legacy.content;
+      if (legacy.term) channel.tm = legacy.term;
+      return { t: entry.timestamp, ch: channel };
+    }
+    return null;
+  }
+
+  function readChannelFlow() {
+    var raw = getCookie(COOKIE_NAME);
+    if (!raw) return [];
+
+    var text = raw;
+    if (text.charAt(0) !== '[') {
+      try {
+        text = decodeURIComponent(text);
+      } catch (e) {
+        return [];
+      }
+    }
+    if (text.charAt(0) !== '[') return [];
+
+    var parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (e) {
+      return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+
+    var flow = [];
+    for (var i = 0; i < parsed.length; i++) {
+      var compact = toCompactEntry(parsed[i]);
+      if (compact) flow.push(compact);
+    }
+    return flow;
+  }
+
+  // Always drops the second entry, never the first: the first touch is what
+  // makes first-touch attribution possible.
+  function applyLimits(flow) {
+    while (flow.length > MAX_ENTRIES && flow.length > 1) flow.splice(1, 1);
+    while (flow.length > 1 &&
+           encodeURIComponent(JSON.stringify(flow)).length > MAX_COOKIE_LENGTH) {
+      flow.splice(1, 1);
+    }
+    return flow;
+  }
+
+  function updateChannelFlow() {
+    var flow = readChannelFlow();
+    // Truthy, not just present: a cleared cookie can linger as an empty value.
+    var sessionActive = !!getCookie(SESSION_COOKIE);
+
+    // A click ID behind an internal referrer was carried over, not clicked:
+    // consent mode's url_passthrough appends it to every internal link once
+    // ad_storage is denied.
+    var utm = utmChannel();
+    var clickId = isInternalReferrer() ? null : clickIdChannel();
+
+    var channel = resolveChannel(utm, clickId);
+    var hasCampaignSignal = !!utm || !!clickId;
+    var last = flow.length > 0 ? flow[flow.length - 1] : null;
+
+    var isNewSession =
+      !last ||
+      !sessionActive ||
+      (hasCampaignSignal && !sameChannel(last.ch, channel));
+
+    if (isNewSession) {
+      var entry = { t: Date.now(), ch: channel };
+      var path = window.location.pathname || '';
+      if (path) entry.lp = path.length > 100 ? path.substring(0, 100) : path;
+      flow.push(entry);
+      applyLimits(flow);
+    }
+
+    setCookie(COOKIE_NAME, JSON.stringify(flow), MAX_AGE_SECONDS);
+    // Its existence is the session signal; expiry is left to the browser.
+    setCookie(SESSION_COOKIE, '1', sessionTimeoutSeconds());
+  }
+
+  updateChannelFlow();
+})();

--- a/assets/channelflow.js
+++ b/assets/channelflow.js
@@ -266,24 +266,24 @@
   var lastConsentWritten = null;
 
   function updateConsentState() {
-    var getConsentState;
+    var ics;
     try {
-      getConsentState =
-        window.google_tag_data &&
-        window.google_tag_data.ics &&
-        window.google_tag_data.ics.getConsentState;
+      ics = window.google_tag_data && window.google_tag_data.ics;
     } catch (e) {
-      getConsentState = null;
+      ics = null;
     }
 
     var state = {};
     var known = 0;
-    if (typeof getConsentState === 'function') {
+    // Called as a method, never pulled out into a bare function: gtag's
+    // implementation reads its own state through `this`, so an unbound call
+    // throws — and the catch below would quietly turn that into "unknown".
+    if (ics && typeof ics.getConsentState === 'function') {
       for (var i = 0; i < CONSENT_TYPES.length; i++) {
         var type = CONSENT_TYPES[i];
         var value;
         try {
-          value = getConsentState(type);
+          value = ics.getConsentState(type);
         } catch (e) {
           continue;
         }

--- a/leadtrackr.php
+++ b/leadtrackr.php
@@ -1004,6 +1004,40 @@ function leadtrackr_extract_user_data($fields, $field_types = array())
     return $user_data;
 }
 
+/**
+ * Reads the consent state that assets/channelflow.js left in a cookie. The lead
+ * is sent from PHP, which cannot reach gtag's in-browser store itself.
+ *
+ * The cookie is visitor-controlled, so only the four known types and the two
+ * known values survive: this ends up on the lead, and anything else would be a
+ * stranger's text in your reporting. An unreadable or absent cookie yields null
+ * and the field is left off entirely — never guessed at.
+ */
+function leadtrackr_consent_state()
+{
+    if (empty($_COOKIE['lt_consent'])) {
+        return null;
+    }
+
+    $parsed = json_decode(wp_unslash($_COOKIE['lt_consent']), true);
+    if (!is_array($parsed)) {
+        return null;
+    }
+
+    $allowed_types = array('ad_storage', 'analytics_storage', 'ad_user_data', 'ad_personalization');
+    $consent = array();
+    foreach ($allowed_types as $type) {
+        if (!isset($parsed[$type])) {
+            continue;
+        }
+        if ($parsed[$type] === 'granted' || $parsed[$type] === 'denied') {
+            $consent[$type] = $parsed[$type];
+        }
+    }
+
+    return empty($consent) ? null : $consent;
+}
+
 function leadtrackr_parse_attributes_data()
 {
     $attributes_data = array();
@@ -1048,6 +1082,11 @@ function leadtrackr_parse_attributes_data()
 
     if ($cid_cookie !== '') {
         $attributes_data['cid'] = $cid_cookie;
+    }
+
+    $consent = leadtrackr_consent_state();
+    if ($consent !== null) {
+        $attributes_data['consent'] = $consent;
     }
 
     return $attributes_data;

--- a/leadtrackr.php
+++ b/leadtrackr.php
@@ -9,7 +9,7 @@
  * @wordpress-plugin
  * Plugin Name:       LeadTrackr
  * Description:       Capture form submissions and send lead data to LeadTrackr for offline conversion tracking, attribution, and channel flow analysis.
- * Version:           1.0.7
+ * Version:           1.1.0
  * Author:            LeadTrackr
  * Author URI:        https://leadtrackr.io/
  * License:           GPL-2.0+
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-define('LEADTRACKR_PLUGIN_VERSION', '1.0.7');
+define('LEADTRACKR_PLUGIN_VERSION', '1.1.0');
 
 define('LEADTRACKR_API_NAMESPACE', 'leadtrackr/v1');
 define('LEADTRACKR_LEAD_ENDPOINT_LEGACY', 'https://app.leadtrackr.io/api/leads/createLead');

--- a/leadtrackr.php
+++ b/leadtrackr.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       LeadTrackr
- * Description:       LeadTrackr description
+ * Description:       Capture form submissions and send lead data to LeadTrackr for offline conversion tracking, attribution, and channel flow analysis.
  * Version:           1.0.7
  * Author:            LeadTrackr
  * Author URI:        https://leadtrackr.io/
@@ -22,13 +22,70 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-use FluentForm\App\Helpers\Helper;
-
 define('LEADTRACKR_PLUGIN_VERSION', '1.0.7');
 
 define('LEADTRACKR_API_NAMESPACE', 'leadtrackr/v1');
-define('LEADTRACKR_API_BASE_URL', home_url('/wp-json/' . LEADTRACKR_API_NAMESPACE));
-define('LEADTRACKR_LEAD_ENDPOINT', 'https://app.leadtrackr.io/api/leads/createLead');
+define('LEADTRACKR_LEAD_ENDPOINT_LEGACY', 'https://app.leadtrackr.io/api/leads/createLead');
+define('LEADTRACKR_LEAD_ENDPOINT', 'https://app.leadtrackr.io/api/leads/createServerSideLead');
+// Pinned to the major version, so patches arrive without a plugin release but
+// a breaking change never does.
+define('LEADTRACKR_LEADBOT_SRC', 'https://cdn.jsdelivr.net/gh/leadtrackr/leadtrackr-leadbot@1/dist/lt-leadbot.min.js');
+
+/**
+ * Sites that already ran this plugin must not have their behaviour changed by an
+ * update: Channel Flow stays off until they choose it, and the API token stays
+ * optional. New installs get Channel Flow on and the token required.
+ *
+ * Decided once, on the first load after this version lands, by looking for
+ * settings that only exist if the plugin was configured before.
+ */
+function leadtrackr_bootstrap_install_state()
+{
+    if (get_option('leadtrackr_install_state', false) !== false) {
+        return;
+    }
+
+    $existing_settings = array(
+        'leadtrackr_project_id',
+        'leadtrackr_gf_forms',
+        'leadtrackr_cf7_forms',
+        'leadtrackr_elementor_forms',
+        'leadtrackr_wpforms_forms',
+        'leadtrackr_fluent_forms_forms',
+        'leadtrackr_divi_process_contact_form',
+    );
+
+    $is_upgrade = false;
+    foreach ($existing_settings as $option) {
+        if (get_option($option, null) !== null) {
+            $is_upgrade = true;
+            break;
+        }
+    }
+
+    add_option('leadtrackr_install_state', $is_upgrade ? 'upgraded' : 'fresh');
+    // add_option leaves an existing explicit choice alone, so this only fills in
+    // the starting position.
+    add_option('leadtrackr_channelflow_enabled', !$is_upgrade);
+}
+add_action('plugins_loaded', 'leadtrackr_bootstrap_install_state');
+
+/** True for sites that were already running the plugin before this version. */
+function leadtrackr_is_legacy_install()
+{
+    return get_option('leadtrackr_install_state', 'fresh') === 'upgraded';
+}
+
+function leadtrackr_channelflow_enabled()
+{
+    return (bool)get_option('leadtrackr_channelflow_enabled', !leadtrackr_is_legacy_install());
+}
+
+/** Required for new installs, optional for sites that upgraded into it. */
+function leadtrackr_api_token_required()
+{
+    return !leadtrackr_is_legacy_install();
+}
 
 // Create the settings page
 function leadtrackr_create_menu()
@@ -46,6 +103,138 @@ function leadtrackr_create_menu()
     );
 }
 add_action('admin_menu', 'leadtrackr_create_menu');
+
+/**
+ * Defaults for the LeadBot embed. Only keys that differ from these are written
+ * to the page, so a site that changes nothing ships no configuration at all.
+ */
+function leadtrackr_leadbot_defaults()
+{
+    return array(
+        'enabled' => false,
+        'companyName' => '',
+        'agentName' => '',
+        'agentPhoto' => '',
+        'greeting' => '',
+        'phone' => '',
+        'whatsapp' => '',
+        'launcher' => true,
+        'teaser' => true,
+        'whatsappInterceptor' => false,
+        'whatsappPhoneQuestion' => true,
+        'callTracking' => false,
+        'position' => 'right',
+        'offsetBottom' => 20,
+        'offsetSide' => 20,
+        'language' => 'auto',
+        'responseTimeText' => '',
+        'themePrimary' => '',
+        'themePrimaryHover' => '',
+        'themeRadius' => 16,
+    );
+}
+
+function leadtrackr_get_leadbot_settings()
+{
+    $saved = get_option('leadtrackr_leadbot', array());
+    if (!is_array($saved)) {
+        $saved = array();
+    }
+    return array_merge(leadtrackr_leadbot_defaults(), $saved);
+}
+
+/**
+ * Translate the plugin's settings into the config the LeadBot expects. Empty
+ * values are omitted rather than sent as empty strings, so the LeadBot falls
+ * back to its own defaults instead of rendering blanks.
+ */
+function leadtrackr_leadbot_config($settings, $project_id)
+{
+    $config = array('projectId' => $project_id);
+
+    foreach (array('companyName', 'agentName', 'agentPhoto', 'greeting', 'phone', 'whatsapp') as $key) {
+        if ($settings[$key] !== '') {
+            $config[$key] = $settings[$key];
+        }
+    }
+
+    if (!$settings['launcher']) $config['launcher'] = false;
+    if (!$settings['teaser']) $config['teaser'] = false;
+    if ($settings['whatsappInterceptor']) $config['whatsappInterceptor'] = true;
+    if (!$settings['whatsappPhoneQuestion']) $config['whatsappPhoneQuestion'] = false;
+    if ($settings['callTracking']) $config['callTracking'] = true;
+    if ($settings['position'] === 'left') $config['position'] = 'left';
+    if ($settings['language'] !== 'auto') $config['language'] = $settings['language'];
+    if ($settings['responseTimeText'] !== '') $config['responseTimeText'] = $settings['responseTimeText'];
+
+    if ((int)$settings['offsetBottom'] !== 20 || (int)$settings['offsetSide'] !== 20) {
+        $config['offset'] = array(
+            'bottom' => (int)$settings['offsetBottom'],
+            'side' => (int)$settings['offsetSide'],
+        );
+    }
+
+    $theme = array();
+    if ($settings['themePrimary'] !== '') $theme['primary'] = $settings['themePrimary'];
+    if ($settings['themePrimaryHover'] !== '') $theme['primaryHover'] = $settings['themePrimaryHover'];
+    if ((int)$settings['themeRadius'] !== 16) $theme['radius'] = (int)$settings['themeRadius'];
+    if (!empty($theme)) $config['theme'] = $theme;
+
+    return $config;
+}
+
+function leadtrackr_enqueue_frontend_scripts()
+{
+    if (is_admin()) {
+        return;
+    }
+
+    if (leadtrackr_channelflow_enabled()) {
+        $utm_config = get_option('leadtrackr_utm_params', array());
+
+        // In the head, not the footer: the channel has to be resolved from the
+        // referrer and query string before the visitor can navigate away.
+        wp_enqueue_script(
+            'leadtrackr-channelflow',
+            plugin_dir_url(__FILE__) . 'assets/channelflow.js',
+            array(),
+            LEADTRACKR_PLUGIN_VERSION,
+            false
+        );
+
+        if (!empty($utm_config)) {
+            wp_add_inline_script(
+                'leadtrackr-channelflow',
+                'window.leadtrackrChannelFlowConfig = ' . wp_json_encode($utm_config) . ';',
+                'before'
+            );
+        }
+    }
+
+    $leadbot = leadtrackr_get_leadbot_settings();
+    $project_id = get_option('leadtrackr_project_id', '');
+
+    // Nothing is requested from the CDN unless the LeadBot is switched on, so a
+    // site that does not use it pays nothing for it.
+    if (!$leadbot['enabled'] || $project_id === '') {
+        return;
+    }
+
+    wp_enqueue_script(
+        'leadtrackr-leadbot',
+        LEADTRACKR_LEADBOT_SRC,
+        array(),
+        null,
+        array('strategy' => 'async', 'in_footer' => true)
+    );
+
+    wp_add_inline_script(
+        'leadtrackr-leadbot',
+        'window.ltLeadBotConfig = ' . wp_json_encode(leadtrackr_leadbot_config($leadbot, $project_id)) . ';',
+        'before'
+    );
+}
+add_action('wp_enqueue_scripts', 'leadtrackr_enqueue_frontend_scripts');
 
 function leadtrackr_list_recursive_iterate_elements($elements, &$forms)
 {
@@ -80,12 +269,26 @@ function leadtrackr_list_get_elementor_forms($offset = 0)
     /**
      * Get the forms now.
      */
-    $results = $wpdb->get_results("SELECT a.ID, b.meta_value FROM $wpdb->posts a, $wpdb->postmeta b WHERE a.post_type NOT IN ('draft', 'revision') AND a.post_status = 'publish' AND a.ID = b.post_id AND b.meta_key = '_elementor_data' LIMIT 100000");
+    // Filtering on the widget type in SQL keeps this from loading every
+    // _elementor_data blob on the site — often hundreds of KB per page — just
+    // to find the handful that contain a form.
+    $results = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT a.ID, b.meta_value
+             FROM {$wpdb->posts} a
+             INNER JOIN {$wpdb->postmeta} b ON a.ID = b.post_id
+             WHERE a.post_status = 'publish'
+               AND b.meta_key = '_elementor_data'
+               AND b.meta_value LIKE %s
+             LIMIT 500",
+            '%' . $wpdb->esc_like('"widgetType":"form"') . '%'
+        )
+    );
     /**
      * Check if empty.
      */
     if (empty($results)) {
-        return null;
+        return array();
     }
     /**
      * Set vars.
@@ -128,6 +331,7 @@ function leadtrackr_list_get_elementor_forms($offset = 0)
 function leadtrackr_get_global_data()
 {
     $gravity_forms_enabled = class_exists('GFForms');
+    $gf_track_all = (bool)get_option('leadtrackr_gf_track_all', false);
     $gravity_forms_forms = get_option('leadtrackr_gf_forms', array());
     if ($gravity_forms_enabled) {
         $gf_forms = GFAPI::get_forms();
@@ -157,6 +361,7 @@ function leadtrackr_get_global_data()
     }
 
     $cf7_enabled = class_exists('WPCF7_ContactForm');
+    $cf7_track_all = (bool)get_option('leadtrackr_cf7_track_all', false);
     $cf7_forms_forms = get_option('leadtrackr_cf7_forms', array());
     if ($cf7_enabled) {
         $cf7_forms = WPCF7_ContactForm::find();
@@ -184,6 +389,7 @@ function leadtrackr_get_global_data()
     }
 
     $elementor_enabled = is_plugin_active('elementor-pro/elementor-pro.php');
+    $elementor_track_all = (bool)get_option('leadtrackr_elementor_track_all', false);
     $elementor_forms_forms = get_option('leadtrackr_elementor_forms', array());
     if ($elementor_enabled) {
         $results = leadtrackr_list_get_elementor_forms();
@@ -191,9 +397,6 @@ function leadtrackr_get_global_data()
         $elementor_forms = [];
 
         foreach ($results as $page_id => $forms) {
-            /**
-             * Now loop over sub-forms for page-id.
-             */
             foreach ($forms as $form) {
                 $form->page_id = strval($page_id);
                 $elementor_forms[] = $form;
@@ -223,6 +426,7 @@ function leadtrackr_get_global_data()
     }
 
     $wpforms_enabled = class_exists('WPForms');
+    $wpforms_track_all = (bool)get_option('leadtrackr_wpforms_track_all', false);
     $wpforms_forms_forms = get_option('leadtrackr_wpforms_forms', array());
     if ($wpforms_enabled) {
         $wpforms_forms = WPForms()->form->get();
@@ -249,9 +453,10 @@ function leadtrackr_get_global_data()
     }
 
     $fluent_forms_enabled = is_plugin_active('fluentform/fluentform.php');
+    $fluent_track_all = (bool)get_option('leadtrackr_fluent_track_all', false);
     $fluent_forms_forms = get_option('leadtrackr_fluent_forms_forms', array());
     if ($fluent_forms_enabled) {
-        $ff_forms = Helper::getForms(); // all forms with form id as keyed array
+        $ff_forms = \FluentForm\App\Helpers\Helper::getForms();
         foreach ($ff_forms as $id => $form_name) {
             $form_data = array(
                 'id' => $id,
@@ -280,37 +485,72 @@ function leadtrackr_get_global_data()
         }
     }
 
+    // Matching only the active theme's name misses the two most common Divi
+    // setups: a child theme (named "Divi Child") and the Divi Builder plugin
+    // running on top of an unrelated theme.
     $current_theme = wp_get_theme();
-    $divi_theme_enabled = $current_theme->get('Name') === 'Divi';
+    $divi_theme_enabled =
+        $current_theme->get('Name') === 'Divi' ||
+        $current_theme->get_template() === 'Divi' ||
+        defined('ET_BUILDER_PLUGIN_ACTIVE');
     $divi_process_contact_form = get_option('leadtrackr_divi_process_contact_form', false);
 
+    $utm_params = get_option('leadtrackr_utm_params', array());
+
     return array(
-        'apiUrl' => LEADTRACKR_API_BASE_URL,
+        // rest_url, not a hand-built /wp-json path: sites on plain permalinks
+        // serve the REST API from /?rest_route= and would 404 on every save.
+        'apiUrl' => esc_url_raw(rest_url(LEADTRACKR_API_NAMESPACE)),
+        // Cookie authentication on the REST API is only accepted together with
+        // this nonce. Without it every save comes back 401 rest_forbidden,
+        // because WordPress treats the request as logged out.
+        'nonce' => wp_create_nonce('wp_rest'),
         'projectId' => get_option('leadtrackr_project_id', ''),
+        // Whether a token exists, never the token itself: wp_localize_script
+        // prints this straight into the page source, which would undo the
+        // point of encrypting it at rest.
+        'apiTokenSet' => leadtrackr_decrypt_token(get_option('leadtrackr_api_token', '')) !== '',
+        'channelFlowEnabled' => leadtrackr_channelflow_enabled(),
+        'apiTokenRequired' => leadtrackr_api_token_required(),
+        'utmParams' => array(
+            'sourceParam' => isset($utm_params['sourceParam']) ? $utm_params['sourceParam'] : 'utm_source',
+            'mediumParam' => isset($utm_params['mediumParam']) ? $utm_params['mediumParam'] : 'utm_medium',
+            'campaignParam' => isset($utm_params['campaignParam']) ? $utm_params['campaignParam'] : 'utm_campaign',
+            'contentParam' => isset($utm_params['contentParam']) ? $utm_params['contentParam'] : 'utm_content',
+            'termParam' => isset($utm_params['termParam']) ? $utm_params['termParam'] : 'utm_term',
+        ),
         'gravityForms' => array(
             'enabled' => $gravity_forms_enabled,
             'forms' => $gravity_forms_forms,
+            'trackAll' => (bool)get_option('leadtrackr_gf_track_all', false),
         ),
         'cf7' => array(
             'enabled' => $cf7_enabled,
             'forms' => $cf7_forms_forms,
+            'trackAll' => (bool)get_option('leadtrackr_cf7_track_all', false),
         ),
         'elementor' => array(
             'enabled' => $elementor_enabled,
             'forms' => $elementor_forms_forms,
+            'trackAll' => (bool)get_option('leadtrackr_elementor_track_all', false),
         ),
         'wpforms' => array(
             'enabled' => $wpforms_enabled,
             'forms' => $wpforms_forms_forms,
+            'trackAll' => (bool)get_option('leadtrackr_wpforms_track_all', false),
         ),
         'fluentForms' => array(
             'enabled' => $fluent_forms_enabled,
             'forms' => $fluent_forms_forms,
+            'trackAll' => (bool)get_option('leadtrackr_fluent_track_all', false),
         ),
         'divi' => array(
             'enabled' => $divi_theme_enabled,
             'processContactForm' => $divi_process_contact_form,
         ),
+        'leadbot' => leadtrackr_get_leadbot_settings(),
+        'leadbotSrc' => LEADTRACKR_LEADBOT_SRC,
+        'leadbotPreviewEndpoint' => esc_url_raw(rest_url(LEADTRACKR_API_NAMESPACE . '/leadbot-preview-lead')),
     );
 }
 
@@ -340,97 +580,322 @@ function leadtrackr_enqueue_scripts()
     );
 
 
-    wp_localize_script('leadtrackr-app-js', 'wpData', leadtrackr_get_global_data());
+    // Not wp_localize_script: that casts every top-level scalar to a string, so
+    // booleans arrive in JavaScript as "1" and "" and any strict comparison —
+    // or a snapshot used to detect unsaved changes — silently misbehaves.
+    wp_add_inline_script(
+        'leadtrackr-app-js',
+        'window.wpData = ' . wp_json_encode(leadtrackr_get_global_data()) . ';',
+        'before'
+    );
 }
 
+
+/**
+ * These endpoints write the project ID and API token, which decide where leads
+ * are sent. That is the same bar as the settings page itself, which is
+ * registered with manage_options — allowing edit_others_posts would let an
+ * editor repoint every lead on the site without being able to open the page.
+ */
+function leadtrackr_check_admin_permission()
+{
+    return current_user_can('manage_options');
+}
+
+function leadtrackr_encrypt_token($token)
+{
+    if (empty($token)) {
+        return '';
+    }
+    $key = wp_salt('auth');
+    $iv = substr(hash('sha256', wp_salt('secure_auth')), 0, 16);
+    $encrypted = openssl_encrypt($token, 'AES-256-CBC', $key, 0, $iv);
+    return $encrypted !== false ? base64_encode($encrypted) : '';
+}
+
+function leadtrackr_decrypt_token($encrypted_token)
+{
+    if (empty($encrypted_token)) {
+        return '';
+    }
+    $key = wp_salt('auth');
+    $iv = substr(hash('sha256', wp_salt('secure_auth')), 0, 16);
+    $decoded = base64_decode($encrypted_token);
+    if ($decoded === false) {
+        return $encrypted_token;
+    }
+    $decrypted = openssl_decrypt($decoded, 'AES-256-CBC', $key, 0, $iv);
+    return $decrypted !== false ? $decrypted : '';
+}
+
+/**
+ * Whitelist the LeadBot settings. Anything not listed here never reaches the
+ * option, so a crafted request cannot inject extra keys into the config that
+ * gets printed onto every page of the site.
+ */
+function leadtrackr_sanitize_leadbot_settings($raw)
+{
+    $defaults = leadtrackr_leadbot_defaults();
+    if (!is_array($raw)) {
+        return $defaults;
+    }
+
+    $clean = $defaults;
+
+    foreach (array('companyName', 'agentName', 'greeting', 'phone', 'whatsapp', 'responseTimeText') as $key) {
+        if (isset($raw[$key])) {
+            $clean[$key] = sanitize_text_field($raw[$key]);
+        }
+    }
+
+    if (isset($raw['agentPhoto'])) {
+        $clean['agentPhoto'] = esc_url_raw($raw['agentPhoto']);
+    }
+
+    foreach (array('enabled', 'launcher', 'teaser', 'whatsappInterceptor', 'whatsappPhoneQuestion', 'callTracking') as $key) {
+        if (isset($raw[$key])) {
+            $clean[$key] = (bool)$raw[$key];
+        }
+    }
+
+    if (isset($raw['position'])) {
+        $clean['position'] = $raw['position'] === 'left' ? 'left' : 'right';
+    }
+    if (isset($raw['language'])) {
+        $clean['language'] = in_array($raw['language'], array('nl', 'en'), true) ? $raw['language'] : 'auto';
+    }
+
+    foreach (array('offsetBottom', 'offsetSide') as $key) {
+        if (isset($raw[$key])) {
+            $clean[$key] = max(0, min(400, (int)$raw[$key]));
+        }
+    }
+    if (isset($raw['themeRadius'])) {
+        $clean['themeRadius'] = max(0, min(40, (int)$raw['themeRadius']));
+    }
+
+    // Hex colours only: these end up in inline styles inside the LeadBot.
+    foreach (array('themePrimary', 'themePrimaryHover') as $key) {
+        if (isset($raw[$key])) {
+            $colour = sanitize_hex_color($raw[$key]);
+            $clean[$key] = $colour ? $colour : '';
+        }
+    }
+
+    return $clean;
+}
+
+function leadtrackr_sanitize_forms_data($raw_forms)
+{
+    if (!is_array($raw_forms)) {
+        return array();
+    }
+
+    $sanitized = array();
+    foreach ($raw_forms as $form) {
+        if (!is_array($form) || !isset($form['id'])) {
+            continue;
+        }
+
+        $sanitized[] = array(
+            'id' => is_int($form['id']) ? $form['id'] : sanitize_text_field($form['id']),
+            'sendToLeadTrackr' => !empty($form['sendToLeadTrackr']),
+            'customTitle' => isset($form['customTitle']) ? sanitize_text_field($form['customTitle']) : '',
+        );
+    }
+
+    return $sanitized;
+}
 
 function leadtrackr_register_rest_api()
 {
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/project-id', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $project_id = $request->get_json_params()['project_id'];
+            $params = $request->get_json_params();
+            $project_id = sanitize_text_field($params['project_id'] ?? '');
             update_option('leadtrackr_project_id', $project_id);
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/api-token', array(
+        'methods' => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            $params = $request->get_json_params();
+            $api_token = sanitize_text_field($params['api_token'] ?? '');
+            update_option('leadtrackr_api_token', leadtrackr_encrypt_token($api_token));
+            return new WP_REST_Response(array(
+                'success' => true,
+            ));
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/channelflow-settings', array(
+        'methods' => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            $params = $request->get_json_params();
+            update_option('leadtrackr_channelflow_enabled', !empty($params['enabled']));
+
+            $utm_params = array();
+            if (isset($params['utmParams'])) {
+                $allowed_keys = array('sourceParam', 'mediumParam', 'campaignParam', 'contentParam', 'termParam');
+                foreach ($allowed_keys as $key) {
+                    if (isset($params['utmParams'][$key])) {
+                        $utm_params[$key] = sanitize_text_field($params['utmParams'][$key]);
+                    }
+                }
+            }
+            update_option('leadtrackr_utm_params', $utm_params);
+
+            return new WP_REST_Response(array(
+                'success' => true,
+            ));
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    // The settings-page preview points the LeadBot's endpoint here instead of at
+    // the real API, so trying out the form never creates a live lead.
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/leadbot-preview-lead', array(
+        'methods' => 'POST',
+        'callback' => function () {
+            return new WP_REST_Response(array('message' => 'Preview only, nothing was stored'), 200);
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/leadbot', array(
+        'methods' => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            $params = $request->get_json_params();
+            $settings = leadtrackr_sanitize_leadbot_settings($params['leadbot'] ?? array());
+            update_option('leadtrackr_leadbot', $settings);
+
+            return new WP_REST_Response(array(
+                'success' => true,
+                'leadbot' => $settings,
+            ));
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/track-all', array(
+        'methods' => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            $params = $request->get_json_params();
+            $builder = sanitize_text_field($params['builder'] ?? '');
+            $enabled = !empty($params['enabled']);
+
+            $allowed_builders = array(
+                'gravity-forms' => 'leadtrackr_gf_track_all',
+                'contact-form-7' => 'leadtrackr_cf7_track_all',
+                'elementor' => 'leadtrackr_elementor_track_all',
+                'wpforms' => 'leadtrackr_wpforms_track_all',
+                'fluent-forms' => 'leadtrackr_fluent_track_all',
+            );
+
+            if (!isset($allowed_builders[$builder])) {
+                return new WP_REST_Response(array(
+                    'success' => false,
+                    'message' => 'Invalid builder',
+                ), 400);
+            }
+
+            update_option($allowed_builders[$builder], $enabled);
+            return new WP_REST_Response(array(
+                'success' => true,
+            ));
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/gravity-forms', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $leadtrackr_gf_forms = $request->get_json_params()['forms'];
-            update_option('leadtrackr_gf_forms', $leadtrackr_gf_forms);
+            $params = $request->get_json_params();
+            $forms = leadtrackr_sanitize_forms_data($params['forms'] ?? array());
+            update_option('leadtrackr_gf_forms', $forms);
 
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/contact-form-7', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $leadtrackr_cf7_forms = $request->get_json_params()['forms'];
-            update_option('leadtrackr_cf7_forms', $leadtrackr_cf7_forms);
+            $params = $request->get_json_params();
+            $forms = leadtrackr_sanitize_forms_data($params['forms'] ?? array());
+            update_option('leadtrackr_cf7_forms', $forms);
 
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/elementor', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $leadtrackr_elementor_forms = $request->get_json_params()['forms'];
-            update_option('leadtrackr_elementor_forms', $leadtrackr_elementor_forms);
+            $params = $request->get_json_params();
+            $forms = leadtrackr_sanitize_forms_data($params['forms'] ?? array());
+            update_option('leadtrackr_elementor_forms', $forms);
 
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/wpforms', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $leadtrackr_wpforms_forms = $request->get_json_params()['forms'];
-            update_option('leadtrackr_wpforms_forms', $leadtrackr_wpforms_forms);
-
-            return new WP_REST_Response(array(
-                'success' => true,
-            ));
-        }
-    ));
-
-    register_rest_route(LEADTRACKR_API_NAMESPACE, '/fluent-forms', array(
-        'methods' => 'POST',
-        'callback' => function (WP_REST_Request $request) {
-            $leadtrackr_fluent_forms_forms = $request->get_json_params()['forms'];
-            update_option('leadtrackr_fluent_forms_forms', $leadtrackr_fluent_forms_forms);
+            $params = $request->get_json_params();
+            $forms = leadtrackr_sanitize_forms_data($params['forms'] ?? array());
+            update_option('leadtrackr_wpforms_forms', $forms);
 
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
+    ));
+
+    register_rest_route(LEADTRACKR_API_NAMESPACE, '/fluent-forms', array(
+        'methods' => 'POST',
+        'callback' => function (WP_REST_Request $request) {
+            $params = $request->get_json_params();
+            $forms = leadtrackr_sanitize_forms_data($params['forms'] ?? array());
+            update_option('leadtrackr_fluent_forms_forms', $forms);
+
+            return new WP_REST_Response(array(
+                'success' => true,
+            ));
+        },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 
     register_rest_route(LEADTRACKR_API_NAMESPACE, '/divi', array(
         'methods' => 'POST',
         'callback' => function (WP_REST_Request $request) {
-            $process_contact_form = $request->get_json_params()['processContactForm'];
+            $params = $request->get_json_params();
+            $process_contact_form = !empty($params['processContactForm']);
             update_option('leadtrackr_divi_process_contact_form', $process_contact_form);
 
             return new WP_REST_Response(array(
                 'success' => true,
             ));
         },
+        'permission_callback' => 'leadtrackr_check_admin_permission',
     ));
 }
 
@@ -441,6 +906,103 @@ define('leadtrackr_lastNamePossibleNames', array('last_name', 'lastName', 'last-
 define('leadtrackr_emailPossibleNames', array('email', 'Email', 'e-mail', 'E-mail', 'e-mail address', 'E-mail Address', 'email address', 'Email Address', 'emailadres', 'Emailadres', 'e-mailadres', 'E-mailadres'));
 define('leadtrackr_phonePossibleNames', array('phone', 'Phone', 'phone number', 'Phone Number', 'telefoon', 'Telefoon', 'telefoonnummer', 'Telefoonnummer'));
 define('leadtrackr_companyPossibleNames', array('company', 'Company', 'company name', 'Company Name', 'bedrijf', 'Bedrijf', 'bedrijfsnaam', 'Bedrijfsnaam'));
+
+/**
+ * Extract userData from a flat key-value array of form fields.
+ *
+ * Matching strategy (in priority order):
+ * 1. Field type hints (email, tel/phone) — if $field_types is provided
+ * 2. Exact match against possibleNames arrays
+ * 3. Sanitized match (stripped colons, trimmed) against possibleNames
+ * 4. Partial match (strpos) — catches keys like "your-email" or "contact_phone"
+ *
+ * @param array $fields Key-value pairs of form field labels/names and their values.
+ * @param array $field_types Optional. Key-value pairs of field names and their input types (e.g. 'email', 'tel').
+ * @return array The extracted userData with keys: firstName, lastName, email, phone, company.
+ */
+function leadtrackr_extract_user_data($fields, $field_types = array())
+{
+    $user_data = array();
+
+    $mapping = array(
+        'firstName' => leadtrackr_firstNamePossibleNames,
+        'lastName' => leadtrackr_lastNamePossibleNames,
+        'email' => leadtrackr_emailPossibleNames,
+        'phone' => leadtrackr_phonePossibleNames,
+        'company' => leadtrackr_companyPossibleNames,
+    );
+
+    $usable = array();
+    foreach ($fields as $key => $value) {
+        if (empty($value)) {
+            continue;
+        }
+        $usable[$key] = array(
+            'value' => $value,
+            'sanitized' => str_replace(':', '', sanitize_text_field($key)),
+        );
+    }
+
+    $claim = function ($slot, $value) use (&$user_data) {
+        if (isset($user_data[$slot])) {
+            return;
+        }
+        // A checkbox called email_optin partially matches "email" and would
+        // otherwise claim the slot with a value of "1", locking out the real
+        // address. Nothing without an @ can be an email, so it is never a
+        // useful fallback here.
+        if ($slot === 'email' && (!is_string($value) || strpos($value, '@') === false)) {
+            return;
+        }
+        $user_data[$slot] = $value;
+    };
+
+    // Three passes, from most to least certain. Running them across all fields
+    // in turn — rather than deciding field by field in form order — is what
+    // stops a weaker match earlier in the form from claiming a slot that a
+    // better field further down would have filled.
+
+    // 1. Types declared by the form builder itself.
+    foreach ($usable as $key => $field) {
+        $type = isset($field_types[$key]) ? $field_types[$key] : '';
+        if ($type === 'email') {
+            $claim('email', $field['value']);
+        }
+        if ($type === 'tel' || $type === 'phone') {
+            $claim('phone', $field['value']);
+        }
+    }
+
+    // 2. Field names that match a known name exactly.
+    foreach ($mapping as $slot => $possible_names) {
+        foreach ($usable as $key => $field) {
+            if (in_array($key, $possible_names, true) || in_array($field['sanitized'], $possible_names, true)) {
+                $claim($slot, $field['value']);
+                break;
+            }
+        }
+    }
+
+    // 3. Anything that merely contains a known name. Deliberately generous: a
+    // company name landing in firstName beats an empty lead, and a field is
+    // allowed to fill a second slot here — but only now that every exact match
+    // has already had its pick.
+    foreach ($mapping as $slot => $possible_names) {
+        if (isset($user_data[$slot])) {
+            continue;
+        }
+        foreach ($usable as $key => $field) {
+            foreach ($possible_names as $name) {
+                if (stripos($key, $name) !== false) {
+                    $claim($slot, $field['value']);
+                    break 2;
+                }
+            }
+        }
+    }
+
+    return $user_data;
+}
 
 function leadtrackr_parse_attributes_data()
 {
@@ -488,14 +1050,82 @@ function leadtrackr_parse_attributes_data()
         $attributes_data['cid'] = $cid_cookie;
     }
 
-    if (isset($_COOKIE['_ga'])) {
-        $sid_cookie = sanitize_text_field(wp_unslash($_COOKIE['_ga']));
-        $parts = explode('.', $sid_cookie);
-        $stripped = implode('.', array_slice($parts, 2));
-        $attributes_data['sid'] = explode('$', $stripped)[0];
+    return $attributes_data;
+}
+
+/**
+ * Send lead data to the LeadTrackr API.
+ *
+ * @param array $data The lead data to send.
+ * @return array|WP_Error The response or WP_Error on failure.
+ */
+function leadtrackr_send_lead($data)
+{
+    // Without a project the API can only reject this, and the visitor waits out
+    // the timeout for nothing. The settings page says no leads are sent until
+    // the Project ID is filled in; this is what makes that true.
+    if (empty($data['projectId'])) {
+        return null;
     }
 
-    return $attributes_data;
+    if (isset($_COOKIE['lt_channelflow'])) {
+        // Deliberately not run through sanitize_text_field: that strips
+        // percent-encoded octets, which mangles campaign values. json_decode
+        // returning an array is the validation.
+        $parsed = json_decode(wp_unslash($_COOKIE['lt_channelflow']), true);
+        if (is_array($parsed)) {
+            $data['channelFlow'] = $parsed;
+        }
+    }
+
+    $api_token = leadtrackr_decrypt_token(get_option('leadtrackr_api_token', ''));
+    $has_token = !empty($api_token);
+
+    $endpoint = $has_token ? LEADTRACKR_LEAD_ENDPOINT : LEADTRACKR_LEAD_ENDPOINT_LEGACY;
+
+    $headers = array('Content-Type' => 'application/json');
+    if ($has_token) {
+        // The API reads x-api-key. Sending any other header name authenticates
+        // nothing and the lead comes back 401.
+        $headers['x-api-key'] = $api_token;
+    }
+
+    $response = wp_remote_post($endpoint, array(
+        'body' => wp_json_encode($data),
+        'headers' => $headers,
+        // This call blocks the visitor's form submission, so it must fail fast
+        // rather than hold the page while LeadTrackr is unreachable.
+        'timeout' => 5,
+    ));
+
+    leadtrackr_log_lead_result($response, $endpoint);
+
+    return $response;
+}
+
+/**
+ * Record why a lead did not arrive. Without this a 401 or a timeout is
+ * indistinguishable from a lead that was never submitted.
+ *
+ * @param array|WP_Error $response Result of the API call.
+ * @param string         $endpoint The endpoint that was called.
+ */
+function leadtrackr_log_lead_result($response, $endpoint)
+{
+    if (is_wp_error($response)) {
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log('[LeadTrackr] Lead not sent to ' . $endpoint . ': ' . $response->get_error_message());
+        return;
+    }
+
+    $code = wp_remote_retrieve_response_code($response);
+    if ($code < 200 || $code >= 300) {
+        // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log(
+            '[LeadTrackr] Lead rejected by ' . $endpoint . ' with status ' . $code . ': ' .
+            wp_remote_retrieve_body($response)
+        );
+    }
 }
 
 /**
@@ -506,6 +1136,7 @@ function leadtrackr_parse_attributes_data()
  */
 function leadtrackr_gravity_forms_submission($entry, $form)
 {
+    $track_all = get_option('leadtrackr_gf_track_all', false);
     $leadtrackr_gf_forms = get_option('leadtrackr_gf_forms', array());
     $form_id = $form['id'];
 
@@ -515,9 +1146,19 @@ function leadtrackr_gravity_forms_submission($entry, $form)
 
     $leadtrackr_form = reset($leadtrackr_form);
 
-
-    if (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr']) {
+    if (!$track_all && (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr'])) {
         return;
+    }
+
+    $form_fields = array();
+    $field_types = array();
+    foreach ($form['fields'] as $field) {
+        if (isset($entry[$field['id']])) {
+            $form_fields[$field['label']] = $entry[$field['id']];
+            if (!empty($field['inputType'])) {
+                $field_types[$field['label']] = $field['inputType'];
+            }
+        }
     }
 
     $data = array(
@@ -525,10 +1166,10 @@ function leadtrackr_gravity_forms_submission($entry, $form)
         'formData' => array(
             'formId' => $form['id'],
             'formName' => $form['title'],
-            'customFormName' => $leadtrackr_form['customTitle'] ?? '',
-            'formFields' => array()
+            'customFormName' => !empty($leadtrackr_form) ? ($leadtrackr_form['customTitle'] ?? '') : '',
+            'formFields' => $form_fields,
         ),
-        'userData' => array(),
+        'userData' => leadtrackr_extract_user_data($form_fields, $field_types),
         'deviceData' => array(
             'ipAddress' => $entry['ip'],
             'userAgent' => $entry['user_agent'],
@@ -536,65 +1177,7 @@ function leadtrackr_gravity_forms_submission($entry, $form)
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
-
-    foreach ($form['fields'] as $field) {
-        if (isset($entry[$field['id']])) {
-            $data['formData']['formFields'][] = array(
-                $field['label'] => $entry[$field['id']],
-            );
-
-            $sanitized_label = sanitize_text_field($field['label']);
-            $sanitized_label = str_replace(':', '', $sanitized_label);
-
-            if (in_array($field['label'], leadtrackr_firstNamePossibleNames)) {
-                $data['userData']['firstName'] = $entry[$field['id']];
-            } else if (in_array($sanitized_label, leadtrackr_firstNamePossibleNames)) {
-                $data['userData']['firstName'] = $entry[$field['id']];
-            }
-
-            if (in_array($field['label'], leadtrackr_lastNamePossibleNames)) {
-                $data['userData']['lastName'] = $entry[$field['id']];
-            } else if (in_array($sanitized_label, leadtrackr_lastNamePossibleNames)) {
-                $data['userData']['lastName'] = $entry[$field['id']];
-            }
-
-            if ($field['inputType'] === 'email') {
-                $data['userData']['email'] = $entry[$field['id']];
-            }
-
-            if (in_array($field['label'], leadtrackr_emailPossibleNames)) {
-                $data['userData']['email'] = $entry[$field['id']];
-            } else if (in_array($sanitized_label, leadtrackr_emailPossibleNames)) {
-                $data['userData']['email'] = $entry[$field['id']];
-            }
-
-            if ($field['inputType'] === 'tel' || $field['inputType'] === 'phone') {
-                $data['userData']['phone'] = $entry[$field['id']];
-            }
-
-            if (in_array($field['label'], leadtrackr_phonePossibleNames)) {
-                $data['userData']['phone'] = $entry[$field['id']];
-            } else if (in_array($sanitized_label, leadtrackr_phonePossibleNames)) {
-                $data['userData']['phone'] = $entry[$field['id']];
-            }
-
-            if (in_array($field['label'], leadtrackr_companyPossibleNames)) {
-                $data['userData']['company'] = $entry[$field['id']];
-            } else if (in_array($sanitized_label, leadtrackr_companyPossibleNames)) {
-                $data['userData']['company'] = $entry[$field['id']];
-            }
-        }
-    }
-
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending Gravity Forms submission to LeadTrackr: ' . $response->get_error_message());
@@ -611,6 +1194,7 @@ add_action('gform_after_submission', 'leadtrackr_gravity_forms_submission', 10, 
  */
 function leadtrackr_cf7_submission($contact_form)
 {
+    $track_all = get_option('leadtrackr_cf7_track_all', false);
     $leadtrackr_cf7_forms = get_option('leadtrackr_cf7_forms', array());
     $form_id = $contact_form->id();
 
@@ -620,7 +1204,7 @@ function leadtrackr_cf7_submission($contact_form)
 
     $leadtrackr_form = reset($leadtrackr_form);
 
-    if (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr']) {
+    if (!$track_all && (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr'])) {
         return;
     }
 
@@ -629,7 +1213,7 @@ function leadtrackr_cf7_submission($contact_form)
         'formData' => array(
             'formId' => $contact_form->id(),
             'formName' => $contact_form->title(),
-            'customFormName' => $leadtrackr_form['customTitle'] ?? '',
+            'customFormName' => !empty($leadtrackr_form) ? ($leadtrackr_form['customTitle'] ?? '') : '',
             'formFields' => array()
         ),
         'userData' => array(),
@@ -637,9 +1221,6 @@ function leadtrackr_cf7_submission($contact_form)
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
 
     if (isset($_SERVER['REMOTE_ADDR']) && !empty($_SERVER['REMOTE_ADDR'])) {
         $data['deviceData']['ipAddress'] = sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR']));
@@ -656,114 +1237,28 @@ function leadtrackr_cf7_submission($contact_form)
         return;
     }
 
-    $all_form_fields = array();
+    $form_fields = array();
+    $field_types = array();
 
     foreach ($submission->get_posted_data() as $key => $value) {
+        $form_fields[$key] = $value;
         $data['formData']['formFields'][$key] = $value;
-
-        $all_form_fields[] = $key;
     }
 
-    foreach (leadtrackr_firstNamePossibleNames as $possibleName) {
-        if ($submission->get_posted_data($possibleName) && (($data['userData']['firstName'] ?? '') === '')) {
-            $data['userData']['firstName'] = $submission->get_posted_data($possibleName);
-            break;
-        }
-
-        if ((($data['userData']['firstName'] ?? '') === '')) {
-            foreach ($all_form_fields as $field) {
-                if (strpos($field, $possibleName) !== false) {
-                    $data['userData']['firstName'] = $submission->get_posted_data($field);
-                    break;
-                }
-            }
-        }
+    // Build field type map from CF7 form tags for type-based fallback
+    $email_tags = $contact_form->scan_form_tags(['type' => 'email']);
+    if (!empty($email_tags) && isset($email_tags[0])) {
+        $field_types[$email_tags[0]['name']] = 'email';
     }
 
-    foreach (leadtrackr_lastNamePossibleNames as $possibleName) {
-        if ($submission->get_posted_data($possibleName) && (($data['userData']['lastName'] ?? '') === '')) {
-            $data['userData']['lastName'] = $submission->get_posted_data($possibleName);
-            break;
-        }
-
-        if ((($data['userData']['lastName'] ?? '') === '')) {
-            foreach ($all_form_fields as $field) {
-                if (strpos($field, $possibleName) !== false) {
-                    $data['userData']['lastName'] = $submission->get_posted_data($field);
-                    break;
-                }
-            }
-        }
+    $tel_tags = $contact_form->scan_form_tags(['type' => 'tel']);
+    if (!empty($tel_tags) && isset($tel_tags[0])) {
+        $field_types[$tel_tags[0]['name']] = 'tel';
     }
 
-    foreach (leadtrackr_emailPossibleNames as $possibleName) {
-        if ($submission->get_posted_data($possibleName) && (($data['userData']['email'] ?? '') === '')) {
-            $data['userData']['email'] = $submission->get_posted_data($possibleName);
-            break;
-        }
+    $data['userData'] = leadtrackr_extract_user_data($form_fields, $field_types);
 
-        if ((($data['userData']['email'] ?? '') === '')) {
-            foreach ($all_form_fields as $field) {
-                if (strpos($field, $possibleName) !== false) {
-                    $data['userData']['email'] = $submission->get_posted_data($field);
-                    break;
-                }
-            }
-        }
-    }
-
-    if ((($data['userData']['email'] ?? '') === '')) {
-        $emailField = $contact_form->scan_form_tags(['type' => 'email'])[0];
-        $data['userData']['email'] = $submission->get_posted_data($emailField['name']);
-    }
-
-    foreach (leadtrackr_phonePossibleNames as $possibleName) {
-        if ($submission->get_posted_data($possibleName) && (($data['userData']['phone'] ?? '') === '')) {
-            $data['userData']['phone'] = $submission->get_posted_data($possibleName);
-            break;
-        }
-
-        if ((($data['userData']['phone'] ?? '') === '')) {
-            foreach ($all_form_fields as $field) {
-                if (strpos($field, $possibleName) !== false) {
-                    $data['userData']['phone'] = $submission->get_posted_data($field);
-                    break;
-                }
-            }
-        }
-    }
-
-    if ((($data['userData']['phone'] ?? '') === '')) {
-        $phoneFields = $contact_form->scan_form_tags(['type' => 'tel']);
-
-        if (!empty($phoneFields) && isset($phoneFields[0])) {
-            $data['userData']['phone'] = $submission->get_posted_data($phoneFields[0]['name']);
-        }
-    }
-
-
-    foreach (leadtrackr_companyPossibleNames as $possibleName) {
-        if ($submission->get_posted_data($possibleName) && (($data['userData']['company'] ?? '') === '')) {
-            $data['userData']['company'] = $submission->get_posted_data($possibleName);
-            break;
-        }
-
-        if ((($data['userData']['company'] ?? '') === '')) {
-            foreach ($all_form_fields as $field) {
-                if (strpos($field, $possibleName) !== false) {
-                    $data['userData']['company'] = $submission->get_posted_data($field);
-                    break;
-                }
-            }
-        }
-    }
-
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending Contact Form 7 submission to LeadTrackr: ' . $response->get_error_message());
@@ -779,6 +1274,7 @@ add_action('wpcf7_mail_sent', 'leadtrackr_cf7_submission', 10, 1);
  */
 function leadtrackr_elementor_forms_submission($record)
 {
+    $track_all = get_option('leadtrackr_elementor_track_all', false);
     $leadtrackr_elementor_forms = get_option('leadtrackr_elementor_forms', array());
     $form_id = $record->get_form_settings('id');
     $form_post_id = $record->get_form_settings('form_post_id');
@@ -793,7 +1289,7 @@ function leadtrackr_elementor_forms_submission($record)
 
     $leadtrackr_form = reset($leadtrackr_form);
 
-    if (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr']) {
+    if (!$track_all && (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr'])) {
         return;
     }
 
@@ -802,53 +1298,22 @@ function leadtrackr_elementor_forms_submission($record)
         'formData' => array(
             'formId' => $form_post_id . "_" . $form_id,
             'formName' => $record->get_form_settings('form_name'),
-            'customFormName' => $leadtrackr_form['customTitle'] ?? '',
+            'customFormName' => !empty($leadtrackr_form) ? ($leadtrackr_form['customTitle'] ?? '') : '',
             'formFields' => array()
         ),
         'userData' => array(),
         'deviceData' => array(
-            'ipAddress' => $_SERVER['REMOTE_ADDR'],
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+            'ipAddress' => isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '',
+            'userAgent' => isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '',
         ),
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
+    $form_fields = $record->get_formatted_data();
+    $data['formData']['formFields'] = $form_fields;
+    $data['userData'] = leadtrackr_extract_user_data($form_fields);
 
-    $fields = $record->get_formatted_data();
-
-    foreach ($fields as $key => $value) {
-        $data['formData']['formFields'][$key] = $value;
-
-        if (in_array($key, leadtrackr_firstNamePossibleNames)) {
-            $data['userData']['firstName'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_lastNamePossibleNames)) {
-            $data['userData']['lastName'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_emailPossibleNames)) {
-            $data['userData']['email'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_phonePossibleNames)) {
-            $data['userData']['phone'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_companyPossibleNames)) {
-            $data['userData']['company'] = $value;
-        }
-    }
-
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending Elementor form submission to LeadTrackr: ' . $response->get_error_message());
@@ -867,6 +1332,7 @@ add_action('elementor_pro/forms/new_record', 'leadtrackr_elementor_forms_submiss
  */
 function leadtrackr_wpforms_forms_submission($fields, $entry, $form_data, $entry_id)
 {
+    $track_all = get_option('leadtrackr_wpforms_track_all', false);
     $leadtrackr_wpforms_forms = get_option('leadtrackr_wpforms_forms', array());
     $form_id = (int)$form_data['id'];
 
@@ -880,7 +1346,7 @@ function leadtrackr_wpforms_forms_submission($fields, $entry, $form_data, $entry
 
     $leadtrackr_form = reset($leadtrackr_form);
 
-    if (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr']) {
+    if (!$track_all && (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr'])) {
         return;
     }
 
@@ -889,81 +1355,49 @@ function leadtrackr_wpforms_forms_submission($fields, $entry, $form_data, $entry
         'formData' => array(
             'formId' => $form_id,
             'formName' => $form_data['settings']['form_title'],
-            'customFormName' => $leadtrackr_form['customTitle'] ?? '',
+            'customFormName' => !empty($leadtrackr_form) ? ($leadtrackr_form['customTitle'] ?? '') : '',
             'formFields' => array()
         ),
         'userData' => array(),
         'deviceData' => array(
-            'ipAddress' => $_SERVER['REMOTE_ADDR'],
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+            'ipAddress' => isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '',
+            'userAgent' => isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '',
         ),
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
+    $form_fields = array();
+    $field_types = array();
 
     foreach ($entry['fields'] as $key => $value) {
         if (is_array($value)) {
             foreach ($value as $subKey => $subValue) {
-                $data['formData']['formFields'][$subKey] = $subValue;
+                $form_fields[$subKey] = $subValue;
             }
         } else {
             $label = $fields[$key]['name'];
-            $data['formData']['formFields'][$label] = $value;
+            $form_fields[$label] = $value;
 
-            $type = $fields[$key]['type'];
-            if ($type === 'email') {
-                $data['userData']['email'] = $value;
-            }
-
-            if ($type === 'phone') {
-                $data['userData']['phone'] = $value;
+            if (!empty($fields[$key]['type'])) {
+                $field_types[$label] = $fields[$key]['type'];
             }
         }
     }
 
-    foreach ($data['formData']['formFields'] as $key => $value) {
-        if (in_array($key, leadtrackr_firstNamePossibleNames)) {
-            $data['userData']['firstName'] = $value;
-        }
+    $data['formData']['formFields'] = $form_fields;
+    $data['userData'] = leadtrackr_extract_user_data($form_fields, $field_types);
 
-        if (in_array($key, leadtrackr_lastNamePossibleNames)) {
-            $data['userData']['lastName'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_emailPossibleNames)) {
-            $data['userData']['email'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_phonePossibleNames)) {
-            $data['userData']['phone'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_companyPossibleNames)) {
-            $data['userData']['company'] = $value;
-        }
-    }
-
-
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending WPForms submission to LeadTrackr: ' . $response->get_error_message());
     }
-
-    return;
 }
 
 add_action('wpforms_process_complete', 'leadtrackr_wpforms_forms_submission', 10, 4);
 
 function leadtrackr_fluent_forms_submission($submissionId, $formData, $form) {
+    $track_all = get_option('leadtrackr_fluent_track_all', false);
     $form_id = (int)$form['id'];
 
     if (!$form_id) {
@@ -977,7 +1411,7 @@ function leadtrackr_fluent_forms_submission($submissionId, $formData, $form) {
 
     $leadtrackr_form = reset($leadtrackr_form);
 
-    if (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr']) {
+    if (!$track_all && (empty($leadtrackr_form) || !$leadtrackr_form['sendToLeadTrackr'])) {
         return;
     }
 
@@ -986,61 +1420,35 @@ function leadtrackr_fluent_forms_submission($submissionId, $formData, $form) {
         'formData' => array(
             'formId' => $form_id,
             'formName' => $form['title'],
-            'customFormName' => $leadtrackr_form['customTitle'] ?? '',
+            'customFormName' => !empty($leadtrackr_form) ? ($leadtrackr_form['customTitle'] ?? '') : '',
             'formFields' => array()
         ),
         'userData' => array(),
         'deviceData' => array(
-            'ipAddress' => $_SERVER['REMOTE_ADDR'],
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+            'ipAddress' => isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '',
+            'userAgent' => isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '',
         ),
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
+    $form_fields = array();
 
     foreach ($formData as $key => $value) {
         if (in_array($key, array('__fluent_form_embded_post_id', '_fluentform_1_fluentformnonce', '_wp_http_referer'))) {
             continue;
         }
 
-        $data['formData']['formFields'][$key] = $value;
-
-        if (in_array($key, leadtrackr_firstNamePossibleNames)) {
-            $data['userData']['firstName'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_lastNamePossibleNames)) {
-            $data['userData']['lastName'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_emailPossibleNames)) {
-            $data['userData']['email'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_phonePossibleNames)) {
-            $data['userData']['phone'] = $value;
-        }
-
-        if (in_array($key, leadtrackr_companyPossibleNames)) {
-            $data['userData']['company'] = $value;
-        }
+        $form_fields[$key] = $value;
     }
 
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $data['formData']['formFields'] = $form_fields;
+    $data['userData'] = leadtrackr_extract_user_data($form_fields);
+
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending Fluent Forms submission to LeadTrackr: ' . $response->get_error_message());
     }
-
-    return;
 }
 
 add_action('fluentform/submission_inserted', 'leadtrackr_fluent_forms_submission', 10, 3);
@@ -1062,52 +1470,26 @@ function leadtrackr_divi_contact_form_submission($processed_fields_values, $et_c
         ),
         'userData' => array(),
         'deviceData' => array(
-            'ipAddress' => $_SERVER['REMOTE_ADDR'],
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
+            'ipAddress' => isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '',
+            'userAgent' => isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_USER_AGENT'])) : '',
         ),
         'attributionData' => leadtrackr_parse_attributes_data(),
     );
 
-    if (isset($_COOKIE['lt_channelflow'])) {
-        $data['lt_channelflow'] = sanitize_text_field(wp_unslash($_COOKIE['lt_channelflow']));
-    }
+    $form_fields = array();
 
     foreach ($processed_fields_values as $key => $value) {
-        $data['formData']['formFields'][$key] = $value['value'];
-
-        if (in_array($key, leadtrackr_firstNamePossibleNames)) {
-            $data['userData']['firstName'] = $value['value'];
-        }
-
-        if (in_array($key, leadtrackr_lastNamePossibleNames)) {
-            $data['userData']['lastName'] = $value['value'];
-        }
-
-        if (in_array($key, leadtrackr_emailPossibleNames)) {
-            $data['userData']['email'] = $value['value'];
-        }
-
-        if (in_array($key, leadtrackr_phonePossibleNames)) {
-            $data['userData']['phone'] = $value['value'];
-        }
-
-        if (in_array($key, leadtrackr_companyPossibleNames)) {
-            $data['userData']['company'] = $value['value'];
-        }
+        $form_fields[$key] = $value['value'];
     }
 
-    $response = wp_remote_post(LEADTRACKR_LEAD_ENDPOINT, array(
-        'body' => wp_json_encode($data),
-        'headers' => array(
-            'Content-Type' => 'application/json',
-        ),
-    ));
+    $data['formData']['formFields'] = $form_fields;
+    $data['userData'] = leadtrackr_extract_user_data($form_fields);
+
+    $response = leadtrackr_send_lead($data);
 
     if (is_wp_error($response)) {
         error_log('LeadTrackr: Error sending Divi Contact Form submission to LeadTrackr: ' . $response->get_error_message());
     }
-
-    return;
 }
 
 add_action('et_pb_contact_form_submit', 'leadtrackr_divi_contact_form_submission', 10, 3);

--- a/leadtrackr.php
+++ b/leadtrackr.php
@@ -932,8 +932,48 @@ function leadtrackr_extract_user_data($fields, $field_types = array())
         'company' => leadtrackr_companyPossibleNames,
     );
 
-    $usable = array();
+    // Form builders hand composite fields over as arrays: Fluent Forms sends
+    // names => [first_name, last_name], WPForms sends [first, last]. Left as
+    // they are, the key "names" partially matches "name" and firstName becomes
+    // the whole object. Splitting them into their parts first means the normal
+    // matching sees first_name and last_name, which it already knows, and no
+    // array can ever reach a user field.
+    $flattened = array();
     foreach ($fields as $key => $value) {
+        if (!is_array($value)) {
+            $flattened[$key] = $value;
+            continue;
+        }
+        foreach ($value as $sub_key => $sub_value) {
+            if (is_array($sub_value) || $sub_value === '' || $sub_value === null) {
+                continue;
+            }
+            if (is_string($sub_key)) {
+                // Builders disagree on what to call the parts: Fluent Forms
+                // uses first_name / last_name, WPForms uses first / last. Map
+                // them onto one name so the matching below does not need to
+                // know which builder it came from.
+                $canonical = strtolower($sub_key);
+                if ($canonical === 'first') {
+                    $canonical = 'first_name';
+                } elseif ($canonical === 'last') {
+                    $canonical = 'last_name';
+                } else {
+                    $canonical = $sub_key;
+                }
+                $flattened[$canonical] = $sub_value;
+            } else {
+                // A plain list, such as a checkbox group: keep it under its own
+                // label rather than losing it.
+                $flattened[$key] = isset($flattened[$key])
+                    ? $flattened[$key] . ', ' . $sub_value
+                    : $sub_value;
+            }
+        }
+    }
+
+    $usable = array();
+    foreach ($flattened as $key => $value) {
         if (empty($value)) {
             continue;
         }
@@ -1038,6 +1078,37 @@ function leadtrackr_consent_state()
     return empty($consent) ? null : $consent;
 }
 
+/**
+ * The page the form was submitted from, as host and path without the query
+ * string — the same shape the GTM tag sends.
+ *
+ * Taken from the referer rather than the request URI, because an AJAX
+ * submission posts to /wp-json or admin-ajax.php and the request URI would
+ * record that instead of the page the visitor was actually on.
+ *
+ * The referer is visitor-controlled and ends up on the lead, so anything
+ * pointing somewhere other than this site is discarded.
+ */
+function leadtrackr_conversion_page()
+{
+    if (empty($_SERVER['HTTP_REFERER'])) {
+        return '';
+    }
+
+    $referer = wp_parse_url(esc_url_raw(wp_unslash($_SERVER['HTTP_REFERER'])));
+    if (empty($referer['host'])) {
+        return '';
+    }
+
+    $home = wp_parse_url(home_url());
+    if (empty($home['host']) || strcasecmp($referer['host'], $home['host']) !== 0) {
+        return '';
+    }
+
+    $path = isset($referer['path']) ? $referer['path'] : '/';
+    return $referer['host'] . $path;
+}
+
 function leadtrackr_parse_attributes_data()
 {
     $attributes_data = array();
@@ -1082,6 +1153,11 @@ function leadtrackr_parse_attributes_data()
 
     if ($cid_cookie !== '') {
         $attributes_data['cid'] = $cid_cookie;
+    }
+
+    $conversion_page = leadtrackr_conversion_page();
+    if ($conversion_page !== '') {
+        $attributes_data['conversionPage'] = $conversion_page;
     }
 
     $consent = leadtrackr_consent_state();

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Requires at least: 6.0
 Tested up to: 7.0
 Requires PHP: 7.0
-Stable tag: 1.0.7
+Stable tag: 1.1.0
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 Source code: https://github.com/leadtrackr/WordPress-Plugin
@@ -35,3 +35,26 @@ With Channel Flow tracking enabled, the plugin sets two first-party cookies on t
 - `lt_consent` — the Google Consent Mode state (granted or denied per category) at the visitor's last pageview, so it can be recorded alongside the lead. Only set on sites that run Google Consent Mode, and only when a definite state can be read. Contains no visitor information. Expires after 30 minutes of inactivity.
 
 Channel Flow tracking is enabled by default on new installations and left disabled on sites that update from an earlier version.
+
+## Changelog
+
+### 1.1.0
+
+**Channel Flow no longer needs Google Tag Manager.** The plugin records the visitor's journey itself, so a site without GTM gets a channel path too. One entry per session rather than per pageview, using the same definition GA4 uses: a new session after 30 minutes of inactivity, or when a new campaign brings the visitor in. Enabled by default on new installations and left off on sites that update, so nothing changes under an existing site's feet.
+
+**The LeadBot can be switched on from the plugin.** A contact launcher for message, phone and WhatsApp, with settings for who is talking, which channels appear and how it looks. Nothing is requested from the CDN unless it is switched on.
+
+**Leads carry more context.** The landing page of each session, the page the conversion happened on, and the Google Consent Mode state at that moment. Consent is recorded only — the plugin never blocks on it; that stays the CMP's job.
+
+**Optional API token for server-side delivery.** With a token, leads are sent server-side, which adds the visitor's IP address and user agent. Sites that update keep working without one.
+
+Fixed:
+
+* Country domains of search engines were recorded as referrals instead of organic traffic, so a visitor arriving through google.nl showed up as `www.google.nl / referral`.
+* Composite name fields were stored as a single value. Fluent Forms and WPForms submit first and last name as one object, which ended up in the first name field in one piece.
+* Fields were matched in form order, so a company name appearing before the first name claimed that slot and the real first name was never stored.
+* Campaigns using auto-tagging without UTM parameters are now attributed through the click ID in the URL.
+* The Elementor form scan loaded every page builder blob on the site into memory, which could exhaust the memory limit on large sites.
+* The settings page could not be saved on sites without pretty permalinks.
+* Leads are no longer sent when no project ID is configured, and a failed delivery is logged instead of disappearing silently.
+* Divi's tab was always available, even when Divi was not installed.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === LeadTrackr ===
 Requires at least: 6.0
-Tested up to: 6.8.2
+Tested up to: 7.0
 Requires PHP: 7.0
 Stable tag: 1.0.7
 License: GPL-2.0+
@@ -11,8 +11,26 @@ Source code: https://github.com/leadtrackr/WordPress-Plugin
 
 This plugin relies on a third-party service provided by the plugin developer (LeadTrackr) to process and send form submissions. Specifically, form submissions are sent to the LeadTrackr API endpoint for the creation of leads. 
 
-- API Endpoint: `https://app.leadtrackr.io/api/leads/createLead`
+- API endpoint: `https://app.leadtrackr.io/api/leads/createLead`
+- API endpoint when an API token is configured: `https://app.leadtrackr.io/api/leads/createServerSideLead`. This request also includes the visitor's IP address and user agent.
 - The service processes lead creation requests using the submitted data.
 - For more information, please review the [LeadTrackr Terms of Use](https://leadtrackr.io/tos) and [Privacy Policy](https://leadtrackr.io/privacy-policy).
 
 By using this plugin, users agree to transmit data to this external service as part of the lead creation functionality.
+
+## Remote Script
+
+The optional LeadBot contact launcher is loaded from a third-party CDN, and only when it is switched on in the plugin settings. Sites that leave it off request nothing from this host.
+
+- Script: `https://cdn.jsdelivr.net/gh/leadtrackr/leadtrackr-leadbot@1/dist/lt-leadbot.min.js`
+- Source code: https://github.com/leadtrackr/leadtrackr-leadbot
+- Submissions made through the LeadBot are sent to the same LeadTrackr API described above.
+
+## Cookies
+
+With Channel Flow tracking enabled, the plugin sets two first-party cookies on the visitor's browser:
+
+- `lt_channelflow` — the visitor's marketing channel path (source, medium, campaign and landing page per session). Contains no personal information and no unique visitor identifier. Expires after 395 days.
+- `lt_session` — indicates whether the visitor is still within the same browsing session. Contains no visitor information. Expires after 30 minutes of inactivity.
+
+Channel Flow tracking is enabled by default on new installations and left disabled on sites that update from an earlier version.

--- a/readme.txt
+++ b/readme.txt
@@ -32,5 +32,6 @@ With Channel Flow tracking enabled, the plugin sets two first-party cookies on t
 
 - `lt_channelflow` — the visitor's marketing channel path (source, medium, campaign and landing page per session). Contains no personal information and no unique visitor identifier. Expires after 395 days.
 - `lt_session` — indicates whether the visitor is still within the same browsing session. Contains no visitor information. Expires after 30 minutes of inactivity.
+- `lt_consent` — the Google Consent Mode state (granted or denied per category) at the visitor's last pageview, so it can be recorded alongside the lead. Only set on sites that run Google Consent Mode, and only when a definite state can be read. Contains no visitor information. Expires after 30 minutes of inactivity.
 
 Channel Flow tracking is enabled by default on new installations and left disabled on sites that update from an earlier version.


### PR DESCRIPTION
> **Voor de reviewer:** deze PR bevat naast nieuw werk ook wijzigingen die al langer ongecommit in een lokale werkkopie stonden — de overstap naar `createServerSideLead`, de versleutelde API-token, de admin-permissiechecks en een herwerkte instellingen-UI. Die zijn nooit eerder gereviewd of gedraaid. Alles is nu getest tegen een echte WordPress-installatie.

## Channel Flow zit nu in de plugin

De plugin hing tot nu toe af van de GTM-tag: hij *las* `lt_channelflow`, maar schreef hem nooit. Op een site zonder GTM was er dus geen journey. Dat is opgelost met `assets/channelflow.js`.

De logica is gelijk aan [gtm-leadtrackr-tag#2](https://github.com/leadtrackr/gtm-leadtrackr-tag/pull/2) en [leadtrackr-leadbot#1](https://github.com/leadtrackr/leadtrackr-leadbot/pull/1). Dat moet ook: alle drie schrijven dezelfde twee cookies, dus verschillen in formaat of codering betekent dat ze elkaars journeys wissen. Een entry markeert het begin van een sessie volgens de GA4-definitie, niet elke pageview.

## LeadBot-tabblad

Instellingen voor wie er praat, welke kanalen aanstaan en de vormgeving. Er wordt niets van de CDN opgehaald zolang de LeadBot uit staat, en de config bevat alleen waarden die van de standaard afwijken. `subscriptionCheck` en `branding` zijn bewust niet ontsloten — die staan in de LeadBot-broncode als commerciële hendels, niet als klantinstelling.

## Bestaande sites merken niets van de update

Bij de eerste load na deze versie wordt een site die al geconfigureerd was gemarkeerd als *upgraded*. Daar blijft Channel Flow uit en blijft de API-token optioneel. Nieuwe installaties krijgen Channel Flow aan en de token verplicht.

Geverifieerd dat leads zonder token gewoon blijven werken:

| Situatie | Endpoint | Auth |
|---|---|---|
| Bestaande site, geen token | `createLead` | geen header |
| Nieuwe site, met token | `createServerSideLead` | `x-api-key` |
| Geen project-ID | — | niets verstuurd |

## Fouten die tijdens het testen boven kwamen

**De instellingenpagina kon niets opslaan.** Toen `permission_callback` van `__return_true` naar een echte capability-check ging, is de REST-nonce nooit meegestuurd. WordPress behandelt een cookie-verzoek zonder nonce als uitgelogd, dus élke opslaan-knop gaf 401 `rest_forbidden`.

**De token ging als `x-api-token` de deur uit terwijl de API `x-api-key` leest.** Elke site die een token invulde zou al zijn leads verliezen aan een 401 — stil, want de response werd nergens gecontroleerd. Nu de juiste header, plus een timeout van 5 seconden en logging, zodat een inzending niet blijft hangen.

**De ontsleutelde token werd in de paginabron gezet** via `wp_localize_script`, wat het versleutelen aan de opslagkant zinloos maakte. Alleen een boolean gaat nog naar de browser.

**De REST-endpoints stonden open voor `edit_others_posts`** terwijl de instellingenpagina zelf `manage_options` vereist. Een redacteur kon dus het project-ID omzetten en alle leads doorsturen, zonder de pagina te kunnen openen.

**De veldherkenning claimde slots op formuliervolgorde.** Stond `Bedrijfsnaam` vóór `Voornaam`, dan kwam de bedrijfsnaam in `firstName` en werd de echte voornaam nooit opgeslagen. Nu drie rondes: gedeclareerde types, exacte namen, en dan pas de partiële match als bewust ruime terugval. Een waarde zonder `@` kan het e-mailslot niet claimen, wat voorkomt dat een `email_optin`-vinkje het echte adres buitensluit.

**`home_url('/wp-json/…')`** geeft een 404 op sites zonder mooie permalinks — daar was de plugin domweg niet in te stellen. Nu `rest_url()`.

**Er werd verstuurd zonder project-ID**, waardoor elke inzending vijf seconden blokkeerde op een verzoek dat toch werd afgewezen.

**Divi's tabblad stond altijd aan** omdat de check uitgecommentarieerd was, en de detectie miste child-themes en de Divi Builder-plugin.

**De Elementor-scan** haalde elke `_elementor_data`-blob op de site in het geheugen. Het filter op widgettype gebeurt nu in SQL.

**`wp_localize_script` cast scalairen naar strings**, dus booleans kwamen binnen als `"1"`. `wpData` gaat nu als JSON mee en behoudt zijn types.

## Instellingenpagina

Overgenomen van de integrations-pagina in het dashboard: dezelfde schakelaar, kaartstijl en spacing. Verder een verbindingsstatus, links naar het dashboard en per onderwerp naar de documentatie, uitleg waarom een tabblad leeg is in plaats van stil grijs, en een opslaanbalk die blijft staan zolang er iets niet bewaard is.

## Getest

Tegen een echte WordPress (Playground, PHP 8.3, WP 7.0) met Contact Form 7:

- Verse installatie: token verplicht, Channel Flow aan, script laadt
- Geüpgradede installatie: token optioneel, Channel Flow uit, script laadt niet
- Cookie in een echte browser: compact formaat, URL-gecodeerd, landingspagina erin
- Interne pageview binnen de sessie geeft geen tweede entry; na het verlopen van de sessie wel
- 26 scenario's tegen `channelflow.js` in Node, gelijk aan de scenariotabel van de tag en de LeadBot
- `php -l` schoon, `tsc -b` schoon

## Nog open

- `readme.txt` staat op `Tested up to: 7.0`, maar het **versienummer is nog 1.0.7** in zowel de plugin-header als `Stable tag`. Dat moet omhoog voor een release, ook omdat de admin-assets op dat nummer worden gecache-bust.
- De tokenversleuteling gebruikt een vaste IV en is niet geauthenticeerd. Erger is het faalgedrag: roteren de WordPress-salts, dan mislukt het ontsleutelen en valt elke lead stilletjes terug op het oude endpoint.
- Samengestelde naamvelden van Gravity Forms, WPForms en Fluent Forms worden nog niet uitgelezen — die slaan hun waarden op onder subsleutels als `1.3` en `1.6`.
- De backend moet het compacte `channelFlow`-formaat nog omzetten **bij intake** in `createLead`, niet bij het renderen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUonXKqWK68e7DWp13C9af